### PR TITLE
Upgrade Nimble to 10.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "c93f16c25af5770f0d3e6af27c9634640946b068",
-          "version": "9.2.1"
+          "revision": "1f3bde57bde12f5e7b07909848c071e9b73d6edc",
+          "version": "10.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
             from: "0.14.0"),
         .package(
             url: "https://github.com/Quick/Nimble.git",
-            from: "9.2.0"),
+            from: "10.0.0"),
         .package(
             name: "SnapshotTesting",
             url: "https://github.com/pointfreeco/swift-snapshot-testing.git",


### PR DESCRIPTION
Upgrades Nimble to 10.0.0 which, inter alia, fixes issue related to running tests on Apple Silicon. See https://github.com/Quick/Nimble/issues/851.