### PR TITLE
Rename childComponentFactory to <nodeName>ComponentFactory

### DIFF
--- a/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/Builder-SwiftUI.stencil
+++ b/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/Builder-SwiftUI.stencil
@@ -91,7 +91,7 @@ internal final class {{ node_name }}Component: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/Builder.stencil
+++ b/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/Builder.stencil
@@ -91,7 +91,7 @@ internal final class {{ node_name }}Component: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/Plugin.stencil
+++ b/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/Plugin.stencil
@@ -48,7 +48,7 @@ internal final class {{ plugin_name }}PluginComponent: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/PluginList.stencil
+++ b/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/PluginList.stencil
@@ -68,7 +68,7 @@ internal final class {{ plugin_list_name }}PluginListComponent: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder.txt
@@ -88,7 +88,7 @@ internal final class <nodeName>Component: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder.txt
@@ -88,7 +88,7 @@ internal final class RootComponent: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeSwiftUI.Builder.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeSwiftUI.Builder.txt
@@ -88,7 +88,7 @@ internal final class <nodeName>Component: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder.txt
@@ -88,7 +88,7 @@ internal final class <nodeName>Component: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeWithoutViewState.Builder.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeWithoutViewState.Builder.txt
@@ -88,7 +88,7 @@ internal final class <nodeName>Component: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeWithoutViewStateSwiftUI.Builder.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeWithoutViewStateSwiftUI.Builder.txt
@@ -88,7 +88,7 @@ internal final class <nodeName>Component: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderPlugin.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderPlugin.1.txt
@@ -48,7 +48,7 @@ internal final class <pluginName>PluginComponent: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderPluginList.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderPluginList.1.txt
@@ -68,7 +68,7 @@ internal final class <pluginListName>PluginListComponent: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-view-injected-xctemplate-___FILEBASENAME___Builder-swift.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-view-injected-xctemplate-___FILEBASENAME___Builder-swift.txt
@@ -87,7 +87,7 @@ internal final class ___VARIABLE_productName___Component: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-without-view-state-xctemplate-___FILEBASENAME___Builder-swift.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-without-view-state-xctemplate-___FILEBASENAME___Builder-swift.txt
@@ -87,7 +87,7 @@ internal final class ___VARIABLE_productName___Component: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-xctemplate-___FILEBASENAME___Builder-swift.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-xctemplate-___FILEBASENAME___Builder-swift.txt
@@ -87,7 +87,7 @@ internal final class ___VARIABLE_productName___Component: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-List-for-Node-xctemplate-___FILEBASENAME___PluginList-swift.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-List-for-Node-xctemplate-___FILEBASENAME___PluginList-swift.txt
@@ -70,7 +70,7 @@ internal final class ___VARIABLE_productName___PluginListComponent: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-for-Node-xctemplate-___FILEBASENAME___Plugin-swift.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-for-Node-xctemplate-___FILEBASENAME___Plugin-swift.txt
@@ -50,7 +50,7 @@ internal final class ___VARIABLE_productName___PluginComponent: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-xctemplate-___FILEBASENAME___Plugin-swift.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-xctemplate-___FILEBASENAME___Plugin-swift.txt
@@ -50,7 +50,7 @@ internal final class ___VARIABLE_productName___PluginComponent: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-SwiftUI-Node-without-view-state-xctemplate-___FILEBASENAME___Builder-swift.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-SwiftUI-Node-without-view-state-xctemplate-___FILEBASENAME___Builder-swift.txt
@@ -87,7 +87,7 @@ internal final class ___VARIABLE_productName___Component: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-SwiftUI-Node-xctemplate-___FILEBASENAME___Builder-swift.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-SwiftUI-Node-xctemplate-___FILEBASENAME___Builder-swift.txt
@@ -87,7 +87,7 @@ internal final class ___VARIABLE_productName___Component: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-view-injected-xctemplate-___FILEBASENAME___Builder-swift.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-view-injected-xctemplate-___FILEBASENAME___Builder-swift.txt
@@ -87,7 +87,7 @@ internal final class ___VARIABLE_productName___Component: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-without-view-state-xctemplate-___FILEBASENAME___Builder-swift.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-without-view-state-xctemplate-___FILEBASENAME___Builder-swift.txt
@@ -87,7 +87,7 @@ internal final class ___VARIABLE_productName___Component: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-xctemplate-___FILEBASENAME___Builder-swift.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-xctemplate-___FILEBASENAME___Builder-swift.txt
@@ -87,7 +87,7 @@ internal final class ___VARIABLE_productName___Component: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-List-for-Node-xctemplate-___FILEBASENAME___PluginList-swift.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-List-for-Node-xctemplate-___FILEBASENAME___PluginList-swift.txt
@@ -70,7 +70,7 @@ internal final class ___VARIABLE_productName___PluginListComponent: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-for-Node-xctemplate-___FILEBASENAME___Plugin-swift.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-for-Node-xctemplate-___FILEBASENAME___Plugin-swift.txt
@@ -50,7 +50,7 @@ internal final class ___VARIABLE_productName___PluginComponent: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-xctemplate-___FILEBASENAME___Plugin-swift.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-xctemplate-___FILEBASENAME___Plugin-swift.txt
@@ -50,7 +50,7 @@ internal final class ___VARIABLE_productName___PluginComponent: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-SwiftUI-Node-without-view-state-xctemplate-___FILEBASENAME___Builder-swift.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-SwiftUI-Node-without-view-state-xctemplate-___FILEBASENAME___Builder-swift.txt
@@ -87,7 +87,7 @@ internal final class ___VARIABLE_productName___Component: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-SwiftUI-Node-xctemplate-___FILEBASENAME___Builder-swift.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-SwiftUI-Node-xctemplate-___FILEBASENAME___Builder-swift.txt
@@ -87,7 +87,7 @@ internal final class ___VARIABLE_productName___Component: Component
 
      Declare child component factories as 'fileprivate' methods.
 
-     fileprivate func childComponentFactory() -> ChildComponent {
+     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
          ChildComponent(parent: self)
      }
 


### PR DESCRIPTION
This PR will rename `childComponentFactory` to `<nodeName>ComponentFactory` in: 
`Builder-SwiftUI.stencil`
`Builder.stencil`
`Plugin.stencil`
`PluginList.stencil`

& regenerated snapshots.