### PR TITLE
Edit Generated folders .gitignore file

### DIFF
--- a/genesis.yml
+++ b/genesis.yml
@@ -251,6 +251,7 @@ files:
   - path: "{{ project|split:' '|join:'_' }}/Generated/.gitignore"
     contents: |
       *
+      !.gitignore
 
   - path: "{{ project|split:' '|join:'_' }}/Resources/Base.lproj/LaunchScreen.storyboard"
     contents: |
@@ -2246,6 +2247,7 @@ files:
   - path: "{{ project|split:' '|join:'_' }}Tests/Generated/.gitignore"
     contents: |
       *
+      !.gitignore
 
   - path: "{{ project|split:' '|join:'_' }}Tests/Tests/{{ project|split:' '|join:'_' }}Tests.swift"
     contents: |


### PR DESCRIPTION
**Problem:**
When creating a Node project from scratch, 2 Generated folders for Needle and Mockolo are created. Both include a `gitignore` file that prevents them from being committed. That's an issue for whoever checks out the project and tries to run it because the scripts that create the project file expect these Generated folders to exist.

**Solution:**
Edit the generated gitignore file to ignore the contents of the folders but not the folders itself.