### PR TITLE
Introduce StencilTemplate and tests

### DIFF
--- a/Sources/XcodeTemplateGeneratorLibrary/StencilTemplate.swift
+++ b/Sources/XcodeTemplateGeneratorLibrary/StencilTemplate.swift
@@ -1,0 +1,89 @@
+//
+//  StencilTemplate.swift
+//  XcodeTemplateGeneratorLibrary
+//
+//  Created by Garric Nahapetian on 11/7/22.
+//
+
+import Foundation
+
+/// Contains a list of all Stencil source files used to generate the Xcode template files.
+public enum StencilTemplate: CaseIterable, CustomStringConvertible {
+
+    case analytics
+    case builder
+    case builderSwiftUI
+    case context
+    case flow
+    case plugin
+    case pluginList
+    case viewController
+    case viewControllerSwiftUI
+    case worker
+
+    /// A textual representation of self for ``CustomStringConvertible`` conformance.
+    public var description: String { filename }
+
+    /// The name of the .stencil file in the XcodeTemplateGeneratorLibrary bundle.
+    public var filename: String {
+        switch self {
+        case .analytics:
+            return "Analytics"
+        case .builder:
+            return "Builder"
+        case .builderSwiftUI:
+            return "Builder-SwiftUI"
+        case .context:
+            return "Context"
+        case .flow:
+            return "Flow"
+        case .plugin:
+            return "Plugin"
+        case .pluginList:
+            return "PluginList"
+        case .viewController:
+            return "ViewController"
+        case .viewControllerSwiftUI:
+            return "ViewController-SwiftUI"
+        case .worker:
+            return "Worker"
+        }
+    }
+
+    /// The desired name of the Stencil for its rendered Swift file.
+    public var outputFilename: String {
+        switch self {
+        case .analytics:
+            return filename
+        case .builder, .builderSwiftUI:
+            return filename.replacingOccurrences(of: "-SwiftUI", with: "")
+        case .context:
+            return filename
+        case .flow:
+            return filename
+        case .plugin:
+            return filename
+        case .pluginList:
+            return filename
+        case .viewController, .viewControllerSwiftUI:
+            return filename.replacingOccurrences(of: "-SwiftUI", with: "")
+        case .worker:
+            return filename
+        }
+    }
+
+    /// The case of self for SwiftUI.
+    ///
+    /// - Parameter swiftUI: whether the SwiftUI version of self should be returned
+    /// - Returns: self
+    public func forSwiftUI(_ swiftUI: Bool) -> Self {
+        switch self {
+        case .analytics, .context, .flow, .plugin, .pluginList, .worker:
+            return self
+        case .builder, .builderSwiftUI:
+            return swiftUI ? .builderSwiftUI : .builder
+        case .viewController, .viewControllerSwiftUI:
+            return swiftUI ? .viewControllerSwiftUI : .viewController
+        }
+    }
+}

--- a/Tests/XcodeTemplateGeneratorLibraryTests/StencilTemplateTests.swift
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/StencilTemplateTests.swift
@@ -1,0 +1,37 @@
+//
+//  StencilTemplateTests.swift
+//  XcodeTemplateGeneratorLibraryTests
+//
+//  Created by Garric Nahapetian on 11/7/22.
+//
+
+import SnapshotTesting
+import XcodeTemplateGeneratorLibrary
+import XCTest
+
+internal final class StencilTemplateTests: XCTestCase {
+
+    internal func testAllCases() {
+        assertSnapshot(matching: StencilTemplate.allCases, as: .dump)
+    }
+
+    internal func testDescription() {
+        assertSnapshot(matching: StencilTemplate.allCases.map(\.description), as: .dump)
+    }
+
+    internal func testFilename() {
+        assertSnapshot(matching: StencilTemplate.allCases.map(\.filename), as: .dump)
+    }
+
+    internal func testOutputFilename() {
+        assertSnapshot(matching: StencilTemplate.allCases.map(\.outputFilename), as: .dump)
+    }
+
+    internal func testForSwiftUIFalse() {
+        assertSnapshot(matching: StencilTemplate.allCases.map { $0.forSwiftUI(false) }, as: .dump)
+    }
+
+    internal func testForSwiftUITrue() {
+        assertSnapshot(matching: StencilTemplate.allCases.map { $0.forSwiftUI(true) }, as: .dump)
+    }
+}

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilTemplateTests/testAllCases.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilTemplateTests/testAllCases.1.txt
@@ -1,0 +1,11 @@
+▿ 10 elements
+  - Analytics
+  - Builder
+  - Builder-SwiftUI
+  - Context
+  - Flow
+  - Plugin
+  - PluginList
+  - ViewController
+  - ViewController-SwiftUI
+  - Worker

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilTemplateTests/testDescription.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilTemplateTests/testDescription.1.txt
@@ -1,0 +1,11 @@
+▿ 10 elements
+  - "Analytics"
+  - "Builder"
+  - "Builder-SwiftUI"
+  - "Context"
+  - "Flow"
+  - "Plugin"
+  - "PluginList"
+  - "ViewController"
+  - "ViewController-SwiftUI"
+  - "Worker"

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilTemplateTests/testFilename.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilTemplateTests/testFilename.1.txt
@@ -1,0 +1,11 @@
+▿ 10 elements
+  - "Analytics"
+  - "Builder"
+  - "Builder-SwiftUI"
+  - "Context"
+  - "Flow"
+  - "Plugin"
+  - "PluginList"
+  - "ViewController"
+  - "ViewController-SwiftUI"
+  - "Worker"

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilTemplateTests/testForSwiftUIFalse.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilTemplateTests/testForSwiftUIFalse.1.txt
@@ -1,0 +1,11 @@
+▿ 10 elements
+  - Analytics
+  - Builder
+  - Builder
+  - Context
+  - Flow
+  - Plugin
+  - PluginList
+  - ViewController
+  - ViewController
+  - Worker

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilTemplateTests/testForSwiftUITrue.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilTemplateTests/testForSwiftUITrue.1.txt
@@ -1,0 +1,11 @@
+▿ 10 elements
+  - Analytics
+  - Builder-SwiftUI
+  - Builder-SwiftUI
+  - Context
+  - Flow
+  - Plugin
+  - PluginList
+  - ViewController-SwiftUI
+  - ViewController-SwiftUI
+  - Worker

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilTemplateTests/testOutputFilename.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilTemplateTests/testOutputFilename.1.txt
@@ -1,0 +1,11 @@
+▿ 10 elements
+  - "Analytics"
+  - "Builder"
+  - "Builder"
+  - "Context"
+  - "Flow"
+  - "Plugin"
+  - "PluginList"
+  - "ViewController"
+  - "ViewController"
+  - "Worker"


### PR DESCRIPTION
If we like the overall direction of [this branch](https://github.com/TinderApp/Nodes/compare/improve-stencil-template-type-usage), then I think I would like to merge this work separately and then I can probably close/re-work [this PR](https://github.com/TinderApp/Nodes/pull/195). The main goal of this is to reduce the number of hardcoded instances of "[StencilTemplate Name]" which - I believe - makes understanding the Generator Library much easier. This will also make the remainder of the State-ViewState refactor work easier.