### PR TITLE
Explore Introduce XcodeFileTemplate and usage

### DIFF
--- a/Sources/XcodeTemplateGeneratorLibrary/Config.swift
+++ b/Sources/XcodeTemplateGeneratorLibrary/Config.swift
@@ -27,7 +27,7 @@ extension XcodeTemplates {
             case standard(swiftUI: Bool), root(swiftUI: Bool), withoutViewState(swiftUI: Bool)
         }
 
-        public var includedTemplates: [String]
+        public var includedTemplates: [XcodeFileTemplate]
         public var fileHeader: String
         public var baseImports: Set<String>
         public var diGraphImports: Set<String>
@@ -111,15 +111,7 @@ extension XcodeTemplates.Config {
 
     // swiftlint:disable:next function_body_length
     public init() {
-        includedTemplates = [
-            "Node",
-            "NodeSwiftUI",
-            "NodeViewInjected",
-            "PluginListNode",
-            "PluginNode",
-            "Plugin",
-            "Worker"
-        ]
+        includedTemplates = XcodeFileTemplate.allCases
         fileHeader = "//___FILEHEADER___"
         baseImports = ["Combine"]
         diGraphImports = ["NeedleFoundation"]

--- a/Sources/XcodeTemplateGeneratorLibrary/XcodeFileTemplate.swift
+++ b/Sources/XcodeTemplateGeneratorLibrary/XcodeFileTemplate.swift
@@ -1,0 +1,21 @@
+//
+//  XcodeFileTemplate.swift
+//  XcodeTemplateGeneratorLibrary
+//
+//  Created by Garric Nahapetian on 11/5/22.
+//
+
+import Foundation
+
+public enum XcodeFileTemplate: String, Decodable, CaseIterable, CustomStringConvertible {
+
+    public var description: String { rawValue }
+
+    case node = "Node"
+    case nodeSwiftUI = "NodeSwiftUI"
+    case nodeViewInjected = "NodeViewInjected"
+    case pluginListNode = "PluginListNode"
+    case pluginNode = "PluginNode"
+    case plugin = "Plugin"
+    case worker = "Worker"
+}

--- a/Sources/XcodeTemplateGeneratorLibrary/XcodeTemplates.swift
+++ b/Sources/XcodeTemplateGeneratorLibrary/XcodeTemplates.swift
@@ -13,25 +13,25 @@ public final class XcodeTemplates {
 
     public init(config: Config) {
         var templates: [XcodeTemplate] = []
-        if config.includedTemplates.contains("Node") {
+        if config.includedTemplates.contains(.node) {
             templates.append(NodeTemplate(config: config))
         }
-        if config.includedTemplates.contains("NodeSwiftUI") {
+        if config.includedTemplates.contains(.nodeSwiftUI) {
             templates.append(NodeTemplate(config: config, swiftUI: true))
         }
-        if config.includedTemplates.contains("NodeViewInjected") {
+        if config.includedTemplates.contains(.nodeViewInjected) {
             templates.append(NodeViewInjectedTemplate(config: config))
         }
-        if config.includedTemplates.contains("PluginListNode") {
+        if config.includedTemplates.contains(.pluginListNode) {
             templates.append(PluginListNodeTemplate(config: config))
         }
-        if config.includedTemplates.contains("PluginNode") {
+        if config.includedTemplates.contains(.pluginNode) {
             templates.append(PluginNodeTemplate(config: config))
         }
-        if config.includedTemplates.contains("Plugin") {
+        if config.includedTemplates.contains(.plugin) {
             templates.append(PluginTemplate(config: config))
         }
-        if config.includedTemplates.contains("Worker") {
+        if config.includedTemplates.contains(.worker) {
             templates.append(WorkerTemplate(config: config))
         }
         self.templates = templates

--- a/Tests/XcodeTemplateGeneratorLibraryTests/TestFactories.swift
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/TestFactories.swift
@@ -16,7 +16,7 @@ extension TestFactories {
 
     func givenConfig() -> Config {
         var config: Config = .init()
-        config.includedTemplates = ["<includedTemplates>"]
+        config.includedTemplates = XcodeFileTemplate.allCases
         config.fileHeader = "<fileHeader>"
         config.baseImports = ["<baseImports>"]
         config.diGraphImports = ["<diGraphImports>"]

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/ConfigTests/testConfig.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/ConfigTests/testConfig.1.txt
@@ -21,9 +21,14 @@
     ▿ Variable
       - name: "flowProperties-name-2"
       - type: "flowProperties-type-2"
-  ▿ includedTemplates: 2 elements
-    - "includedTemplates-1"
-    - "includedTemplates-2"
+  ▿ includedTemplates: 7 elements
+    - Node
+    - NodeSwiftUI
+    - NodeViewInjected
+    - PluginListNode
+    - PluginNode
+    - Plugin
+    - Worker
   - publisherFailureType: "publisherFailureType"
   - publisherType: "publisherType"
   - rootViewControllerMethods: "rootViewControllerMethods"

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/ConfigTests/testDefaultConfig.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/ConfigTests/testDefaultConfig.1.txt
@@ -8,13 +8,13 @@
   - fileHeader: "//___FILEHEADER___"
   - flowProperties: 0 elements
   ▿ includedTemplates: 7 elements
-    - "Node"
-    - "NodeSwiftUI"
-    - "NodeViewInjected"
-    - "PluginListNode"
-    - "PluginNode"
-    - "Plugin"
-    - "Worker"
+    - Node
+    - NodeSwiftUI
+    - NodeViewInjected
+    - PluginListNode
+    - PluginNode
+    - Plugin
+    - Worker
   - publisherFailureType: ", Never"
   - publisherType: "AnyPublisher"
   - rootViewControllerMethods: "override func viewDidLoad() {\n    super.viewDidLoad()\n    view.backgroundColor = .systemBackground\n}\n\noverride func viewWillAppear(_ animated: Bool) {\n    super.viewWillAppear(animated)\n    observe(viewState).store(in: &cancellables)\n}\n\noverride func viewDidAppear(_ animated: Bool) {\n    super.viewDidAppear(animated)\n    receiver?.viewDidAppear()\n}\n\noverride func viewWillDisappear(_ animated: Bool) {\n    super.viewWillDisappear(animated)\n    cancellables.removeAll()\n}"

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/ConfigTests/testEmptyConfig.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/ConfigTests/testEmptyConfig.1.txt
@@ -8,13 +8,13 @@
   - fileHeader: "//___FILEHEADER___"
   - flowProperties: 0 elements
   ▿ includedTemplates: 7 elements
-    - "Node"
-    - "NodeSwiftUI"
-    - "NodeViewInjected"
-    - "PluginListNode"
-    - "PluginNode"
-    - "Plugin"
-    - "Worker"
+    - Node
+    - NodeSwiftUI
+    - NodeViewInjected
+    - PluginListNode
+    - PluginNode
+    - Plugin
+    - Worker
   - publisherFailureType: ", Never"
   - publisherType: "AnyPublisher"
   - rootViewControllerMethods: "override func viewDidLoad() {\n    super.viewDidLoad()\n    view.backgroundColor = .systemBackground\n}\n\noverride func viewWillAppear(_ animated: Bool) {\n    super.viewWillAppear(animated)\n    observe(viewState).store(in: &cancellables)\n}\n\noverride func viewDidAppear(_ animated: Bool) {\n    super.viewDidAppear(animated)\n    receiver?.viewDidAppear()\n}\n\noverride func viewWillDisappear(_ animated: Bool) {\n    super.viewWillDisappear(animated)\n    cancellables.removeAll()\n}"


### PR DESCRIPTION
Do we like this? Enum is public so consumers can use cases to define which Xcode File Templates they want instead of using hard coded strings. If we like this, I can add additional tests.