### PR TITLE
Update sortOrder of templates

### DIFF
--- a/Sources/XcodeTemplateGeneratorLibrary/Templates/NodeTemplate.swift
+++ b/Sources/XcodeTemplateGeneratorLibrary/Templates/NodeTemplate.swift
@@ -13,14 +13,7 @@ internal struct NodeTemplate: XcodeTemplate {
     internal let stencils: [String]
     internal let filenames: [String: String]
     internal let context: Context
-
-    internal let propertyList: PropertyList =
-        .init(description: "The source files implementing a Node.",
-              sortOrder: 1) {
-            Option(identifier: "productName",
-                   name: "Node name:",
-                   description: "The name of the Node")
-        }
+    internal let propertyList: PropertyList
 
     internal init(for kind: UIFramework.Kind, config: Config) throws {
         let uiFramework: UIFramework = try config.uiFramework(for: kind)
@@ -61,5 +54,12 @@ internal struct NodeTemplate: XcodeTemplate {
             publisherFailureType: config.publisherFailureType,
             cancellableType: config.cancellableType
         )
+        propertyList = PropertyList(description: "The source files implementing a Node.",
+                                    // swiftlint:disable:next force_unwrapping
+                                    sortOrder: UIFramework.Kind.allCases.firstIndex(of: kind)! + 1) {
+            Option(identifier: "productName",
+                   name: "Node name:",
+                   description: "The name of the Node")
+        }
     }
 }

--- a/Sources/XcodeTemplateGeneratorLibrary/Templates/NodeViewInjectedTemplate.swift
+++ b/Sources/XcodeTemplateGeneratorLibrary/Templates/NodeViewInjectedTemplate.swift
@@ -15,7 +15,7 @@ internal struct NodeViewInjectedTemplate: XcodeTemplate {
 
     internal let propertyList: PropertyList =
         .init(description: "The source files implementing a Node.",
-              sortOrder: 3) {
+              sortOrder: 5) {
             Option(identifier: "productName",
                    name: "Node name:",
                    description: "The name of the Node")

--- a/Sources/XcodeTemplateGeneratorLibrary/Templates/PluginListNodeTemplate.swift
+++ b/Sources/XcodeTemplateGeneratorLibrary/Templates/PluginListNodeTemplate.swift
@@ -15,7 +15,7 @@ internal struct PluginListNodeTemplate: XcodeTemplate {
 
     internal let propertyList: PropertyList =
         .init(description: "The source file implementing a Plugin List.",
-              sortOrder: 4) {
+              sortOrder: 6) {
             Option(identifier: "productName",
                    name: "Plugin List name:",
                    description: "The name of the Plugin List")

--- a/Sources/XcodeTemplateGeneratorLibrary/Templates/PluginNodeTemplate.swift
+++ b/Sources/XcodeTemplateGeneratorLibrary/Templates/PluginNodeTemplate.swift
@@ -15,7 +15,7 @@ internal struct PluginNodeTemplate: XcodeTemplate {
 
     internal let propertyList: PropertyList =
         .init(description: "The source file implementing a Plugin for a Node.",
-              sortOrder: 5) {
+              sortOrder: 7) {
             Option(identifier: "productName",
                    name: "Node name:",
                    description: "The name of the Plugin")

--- a/Sources/XcodeTemplateGeneratorLibrary/Templates/PluginTemplate.swift
+++ b/Sources/XcodeTemplateGeneratorLibrary/Templates/PluginTemplate.swift
@@ -15,7 +15,7 @@ internal struct PluginTemplate: XcodeTemplate {
 
     internal let propertyList: PropertyList =
         .init(description: "The source file implementing a Plugin.",
-              sortOrder: 6) {
+              sortOrder: 8) {
             Option(identifier: "productName",
                    name: "Plugin name:",
                    description: "The name of the Plugin")

--- a/Sources/XcodeTemplateGeneratorLibrary/Templates/WorkerTemplate.swift
+++ b/Sources/XcodeTemplateGeneratorLibrary/Templates/WorkerTemplate.swift
@@ -15,7 +15,7 @@ internal struct WorkerTemplate: XcodeTemplate {
 
     internal let propertyList: PropertyList =
         .init(description: "The source file implementing a Worker.",
-              sortOrder: 7) {
+              sortOrder: 9) {
             Option(identifier: "productName",
                    name: "Worker name:",
                    description: "The name of the Worker")

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/TemplatesTests/testNodeSwiftUITemplate.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/TemplatesTests/testNodeSwiftUITemplate.1.txt
@@ -75,7 +75,7 @@
         - required: true
         - type: "text"
     - platforms: 0 elements
-    - sortOrder: 1
+    - sortOrder: 3
     - summary: "The source files implementing a Node"
     - supportsSwiftPackage: true
   ▿ stencils: 6 elements

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/TemplatesTests/testNodeTemplate.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/TemplatesTests/testNodeTemplate.1.txt
@@ -69,7 +69,7 @@
         - required: true
         - type: "text"
     - platforms: 0 elements
-    - sortOrder: 1
+    - sortOrder: 2
     - summary: "The source files implementing a Node"
     - supportsSwiftPackage: true
   ▿ stencils: 6 elements

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/TemplatesTests/testNodeViewInjectedTemplate.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/TemplatesTests/testNodeViewInjectedTemplate.1.txt
@@ -52,7 +52,7 @@
         - required: true
         - type: "text"
     - platforms: 0 elements
-    - sortOrder: 3
+    - sortOrder: 5
     - summary: "The source files implementing a Node"
     - supportsSwiftPackage: true
   ▿ stencils: 5 elements

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/TemplatesTests/testPluginListNodeTemplate.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/TemplatesTests/testPluginListNodeTemplate.1.txt
@@ -24,7 +24,7 @@
         - required: true
         - type: "text"
     - platforms: 0 elements
-    - sortOrder: 4
+    - sortOrder: 6
     - summary: "The source file implementing a Plugin List"
     - supportsSwiftPackage: true
   ▿ stencils: 1 element

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/TemplatesTests/testPluginNodeTemplate.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/TemplatesTests/testPluginNodeTemplate.1.txt
@@ -24,7 +24,7 @@
         - required: true
         - type: "text"
     - platforms: 0 elements
-    - sortOrder: 5
+    - sortOrder: 7
     - summary: "The source file implementing a Plugin for a Node"
     - supportsSwiftPackage: true
   ▿ stencils: 1 element

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/TemplatesTests/testPluginTemplate.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/TemplatesTests/testPluginTemplate.1.txt
@@ -33,7 +33,7 @@
         - required: true
         - type: "text"
     - platforms: 0 elements
-    - sortOrder: 6
+    - sortOrder: 8
     - summary: "The source file implementing a Plugin"
     - supportsSwiftPackage: true
   ▿ stencils: 1 element

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/TemplatesTests/testWorkerTemplate.1.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/TemplatesTests/testWorkerTemplate.1.txt
@@ -32,7 +32,7 @@
         - required: true
         - type: "text"
     - platforms: 0 elements
-    - sortOrder: 7
+    - sortOrder: 9
     - summary: "The source file implementing a Worker"
     - supportsSwiftPackage: true
   ▿ stencils: 1 element

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-SwiftUI-xctemplate-TemplateInfo-plist.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-SwiftUI-xctemplate-TemplateInfo-plist.txt
@@ -32,7 +32,7 @@
 	<key>Platforms</key>
 	<array/>
 	<key>SortOrder</key>
-	<integer>1</integer>
+	<integer>3</integer>
 	<key>Summary</key>
 	<string>The source files implementing a Node</string>
 	<key>SupportsSwiftPackage</key>

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-UIKit-xctemplate-TemplateInfo-plist.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-UIKit-xctemplate-TemplateInfo-plist.txt
@@ -32,7 +32,7 @@
 	<key>Platforms</key>
 	<array/>
 	<key>SortOrder</key>
-	<integer>1</integer>
+	<integer>2</integer>
 	<key>Summary</key>
 	<string>The source files implementing a Node</string>
 	<key>SupportsSwiftPackage</key>

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-view-injected-xctemplate-TemplateInfo-plist.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-view-injected-xctemplate-TemplateInfo-plist.txt
@@ -32,7 +32,7 @@
 	<key>Platforms</key>
 	<array/>
 	<key>SortOrder</key>
-	<integer>3</integer>
+	<integer>5</integer>
 	<key>Summary</key>
 	<string>The source files implementing a Node</string>
 	<key>SupportsSwiftPackage</key>

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-List-for-Node-xctemplate-TemplateInfo-plist.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-List-for-Node-xctemplate-TemplateInfo-plist.txt
@@ -32,7 +32,7 @@
 	<key>Platforms</key>
 	<array/>
 	<key>SortOrder</key>
-	<integer>4</integer>
+	<integer>6</integer>
 	<key>Summary</key>
 	<string>The source file implementing a Plugin List</string>
 	<key>SupportsSwiftPackage</key>

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-for-Node-xctemplate-TemplateInfo-plist.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-for-Node-xctemplate-TemplateInfo-plist.txt
@@ -32,7 +32,7 @@
 	<key>Platforms</key>
 	<array/>
 	<key>SortOrder</key>
-	<integer>5</integer>
+	<integer>7</integer>
 	<key>Summary</key>
 	<string>The source file implementing a Plugin for a Node</string>
 	<key>SupportsSwiftPackage</key>

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-xctemplate-TemplateInfo-plist.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-xctemplate-TemplateInfo-plist.txt
@@ -46,7 +46,7 @@
 	<key>Platforms</key>
 	<array/>
 	<key>SortOrder</key>
-	<integer>6</integer>
+	<integer>8</integer>
 	<key>Summary</key>
 	<string>The source file implementing a Plugin</string>
 	<key>SupportsSwiftPackage</key>

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Worker-xctemplate-TemplateInfo-plist.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Worker-xctemplate-TemplateInfo-plist.txt
@@ -46,7 +46,7 @@
 	<key>Platforms</key>
 	<array/>
 	<key>SortOrder</key>
-	<integer>7</integer>
+	<integer>9</integer>
 	<key>Summary</key>
 	<string>The source file implementing a Worker</string>
 	<key>SupportsSwiftPackage</key>

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-SwiftUI-xctemplate-TemplateInfo-plist.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-SwiftUI-xctemplate-TemplateInfo-plist.txt
@@ -32,7 +32,7 @@
 	<key>Platforms</key>
 	<array/>
 	<key>SortOrder</key>
-	<integer>1</integer>
+	<integer>3</integer>
 	<key>Summary</key>
 	<string>The source files implementing a Node</string>
 	<key>SupportsSwiftPackage</key>

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-UIKit-xctemplate-TemplateInfo-plist.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-UIKit-xctemplate-TemplateInfo-plist.txt
@@ -32,7 +32,7 @@
 	<key>Platforms</key>
 	<array/>
 	<key>SortOrder</key>
-	<integer>1</integer>
+	<integer>2</integer>
 	<key>Summary</key>
 	<string>The source files implementing a Node</string>
 	<key>SupportsSwiftPackage</key>

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-view-injected-xctemplate-TemplateInfo-plist.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-view-injected-xctemplate-TemplateInfo-plist.txt
@@ -32,7 +32,7 @@
 	<key>Platforms</key>
 	<array/>
 	<key>SortOrder</key>
-	<integer>3</integer>
+	<integer>5</integer>
 	<key>Summary</key>
 	<string>The source files implementing a Node</string>
 	<key>SupportsSwiftPackage</key>

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-List-for-Node-xctemplate-TemplateInfo-plist.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-List-for-Node-xctemplate-TemplateInfo-plist.txt
@@ -32,7 +32,7 @@
 	<key>Platforms</key>
 	<array/>
 	<key>SortOrder</key>
-	<integer>4</integer>
+	<integer>6</integer>
 	<key>Summary</key>
 	<string>The source file implementing a Plugin List</string>
 	<key>SupportsSwiftPackage</key>

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-for-Node-xctemplate-TemplateInfo-plist.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-for-Node-xctemplate-TemplateInfo-plist.txt
@@ -32,7 +32,7 @@
 	<key>Platforms</key>
 	<array/>
 	<key>SortOrder</key>
-	<integer>5</integer>
+	<integer>7</integer>
 	<key>Summary</key>
 	<string>The source file implementing a Plugin for a Node</string>
 	<key>SupportsSwiftPackage</key>

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-xctemplate-TemplateInfo-plist.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-xctemplate-TemplateInfo-plist.txt
@@ -46,7 +46,7 @@
 	<key>Platforms</key>
 	<array/>
 	<key>SortOrder</key>
-	<integer>6</integer>
+	<integer>8</integer>
 	<key>Summary</key>
 	<string>The source file implementing a Plugin</string>
 	<key>SupportsSwiftPackage</key>

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Worker-xctemplate-TemplateInfo-plist.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Worker-xctemplate-TemplateInfo-plist.txt
@@ -46,7 +46,7 @@
 	<key>Platforms</key>
 	<array/>
 	<key>SortOrder</key>
-	<integer>7</integer>
+	<integer>9</integer>
 	<key>Summary</key>
 	<string>The source file implementing a Worker</string>
 	<key>SupportsSwiftPackage</key>


### PR DESCRIPTION
This PR will ensure that the AppKit, UIKit, SwiftUI, and Custom Xcode File Templates appears in this order in the Xcode Template Picker UI. The other templates start at sort order index 5. The ultimate sort order appears like this:
1. AppKit
2. UIKit
3. SwiftUI
4. Custom
5. NodeViewInjected
6. PluginListNode
7. PluginNode
8. Plugin
9. Worker