### PR TITLE
Rename ```ViewControllable``` ```withModalStyle``` omitted argument parameter 

### DIFF
--- a/Sources/Nodes/ViewControllable/ViewControllable.swift
+++ b/Sources/Nodes/ViewControllable/ViewControllable.swift
@@ -21,7 +21,7 @@ public protocol ViewControllable: AnyObject {
     ///
     /// - Returns: The `self` instance with the given ``ModalStyle`` applied.
     @discardableResult
-    func withModalStyle(_ style: ModalStyle) -> Self
+    func withModalStyle(_ modalStyle: ModalStyle) -> Self
 
     /// Presents a ``ViewControllable`` instance.
     ///


### PR DESCRIPTION
Rename ```withModalStyle``` omitted argument parameter.

```func withModalStyle(_ style: ModalStyle) -> Self``` > ```func withModalStyle(_ modalStyle: ModalStyle) -> Self```

No other changes are required as omitted argument parameters are not required in protocol definition and conforming types are already using ```modalStyle``` for parameter name. 