### PR TITLE
Make ```DebugInformation``` classes final

### DIFF
--- a/Sources/Nodes/Utilities/DebugInformation.swift
+++ b/Sources/Nodes/Utilities/DebugInformation.swift
@@ -51,6 +51,8 @@ public enum DebugInformation {
                                      flowIdentifier: ObjectIdentifier,
                                      flowType: Flow.Type)
 
+    private typealias UserInfo = [UserInfoKey: Any]
+
     public final class Factory {
 
         private weak var object: AnyObject?
@@ -275,8 +277,6 @@ public enum DebugInformation {
             notification = Notification(name: Self.name, userInfo: userInfo)
         }
     }
-
-    private typealias UserInfo = [UserInfoKey: Any]
 
     private enum UserInfoKey {
         case flowIdentifier


### PR DESCRIPTION
Make all ```DebugInformation``` types ```final```.
```DebugInformation``` ```userInfo``` were previously using ```String``` for keys. Replace ```String``` keys in ```userInfo``` with new ```UserInfoKey``` to prevent accidentally mistyping key.
Also, cast all ```Notification.userInfo``` dictionaries to new ```UserInfo``` typealias ```[UserInfoKey: Any]```.
We may opt to send a custom object in ```Notification``` rather than use ```userInfo``` dictionary at all in the future.