### PR TITLE
Remove view_state_publisher from most stencils

### DIFF
--- a/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/Builder-SwiftUI.stencil
+++ b/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/Builder-SwiftUI.stencil
@@ -155,20 +155,19 @@ internal final class {{ node_name }}BuilderImp: AbstractBuilder
     ) -> {{ node_name }}Flow {
         let listener: {{ node_name }}Listener = dynamicBuildDependency
         let analytics: {{ node_name }}AnalyticsImp = .init()
-        let {% if view_state_publisher %}viewStateWorker{% else %}worker{% endif %}: {{ worker_name }}WorkerImp = .init(
+        let viewStateWorker: {{ worker_name }}WorkerImp = .init(
             analytics: analytics
-        ){% if view_state_publisher %}
+        )
         var view: {{ node_name }}View = .init(
             viewState: viewStateWorker.viewState
-        ){% else %}
-        var view: {{ node_name }}View = .init(){% endif %}
+        )
         view.analytics = analytics
         let viewController: {{ node_name }}ViewController = .init(
             rootView: view
         )
         let context: {{ node_name }}ContextImp = .init(
             presentable: viewController,
-            workers: [{% if view_state_publisher %}viewStateWorker{% else %}worker{% endif %}],
+            workers: [viewStateWorker],
             analytics: analytics
         )
         context.listener = listener

--- a/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/Builder.stencil
+++ b/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/Builder.stencil
@@ -155,17 +155,16 @@ internal final class {{ node_name }}BuilderImp: AbstractBuilder
     ) -> {{ node_name }}Flow {
         let listener: {{ node_name }}Listener = dynamicBuildDependency
         let analytics: {{ node_name }}AnalyticsImp = .init()
-        let {% if view_state_publisher %}viewStateWorker{% else %}worker{% endif %}: {{ worker_name }}WorkerImp = .init(
+        let viewStateWorker: {{ worker_name }}WorkerImp = .init(
             analytics: analytics
-        ){% if view_state_publisher %}
+        )
         let viewController: {{ node_name }}ViewController = .init(
             viewState: viewStateWorker.viewState
-        ){% else %}
-        let viewController: {{ node_name }}ViewController = .init(){% endif %}
+        )
         viewController.analytics = analytics
         let context: {{ node_name }}ContextImp = .init(
             presentable: viewController,
-            workers: [{% if view_state_publisher %}viewStateWorker{% else %}worker{% endif %}],
+            workers: [viewStateWorker],
             analytics: analytics
         )
         context.listener = listener

--- a/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/ViewController-SwiftUI.stencil
+++ b/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/ViewController-SwiftUI.stencil
@@ -1,7 +1,7 @@
 {{ file_header }}{% if view_controller_imports %}
 {% for import in view_controller_imports %}
 import {{ import }}{% endfor %}{% endif %}
-{% if view_state_publisher %}
+
 /**
  PURPOSE:
  The view state.
@@ -11,7 +11,7 @@ internal struct {{ node_name }}ViewState: Equatable, InitialStateProviding {
     /// The initial view state.
     internal static var initialState: {{ node_name }}ViewState = .init()
 }
-{% endif %}
+
 /**
  PURPOSE:
  The interface that the View will speak to the Context through. Used for informing the Context of
@@ -48,11 +48,10 @@ extension {{ node_name }}ViewController: {{ node_name }}ViewControllable {}
 internal struct {{ node_name }}View: NodesView {
 
     /// The body of the view.
-    internal var body: some View {{ '{' }}{% if view_state_publisher %}
+    internal var body: some View {{ '{' }}
         WithViewState(viewState) { viewState in
             Text(verbatim: "\(type(of: viewState))")
-        }{% else %}
-        Text("{{ node_name }}"){% endif %}
+        }
     }
 
     /// The view receiver.
@@ -60,7 +59,7 @@ internal struct {{ node_name }}View: NodesView {
 
     /// The Analytics instance.
     internal weak var analytics: {{ node_name }}Analytics?
-{% if view_state_publisher %}
+
     /// The view state publisher.
     private let viewState: {{ publisher_type }}<{{ node_name }}ViewState{{ publisher_failure_type }}>
 
@@ -69,9 +68,7 @@ internal struct {{ node_name }}View: NodesView {
     internal init(viewState: {{ publisher_type }}<{{ node_name }}ViewState{{ publisher_failure_type }}>) {
         self.viewState = viewState{% if view_state_operators %}
             {{ view_state_operators|indent:12 }}{% endif %}
-    }{% else %}
-    /// The initializer.
-    internal init() {}{% endif %}
+    }
 }
 
 /**
@@ -79,11 +76,11 @@ internal struct {{ node_name }}View: NodesView {
  The SwiftUI preview (excluded from release builds).
  */
 internal struct {{ node_name }}View_Previews: PreviewProvider {
-{% if view_state_publisher %}
+
     private static let viewState: AnyPublisher<{{ node_name }}ViewState{{ publisher_failure_type }}> =
         Just<{{ node_name }}ViewState>(.initialState).eraseToAnyPublisher()
-{% endif %}
+
     internal static var previews: some View {
-        {{ node_name }}View({% if view_state_publisher %}viewState: viewState{% endif %})
+        {{ node_name }}View(viewState: viewState)
     }
 }

--- a/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/ViewController.stencil
+++ b/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/ViewController.stencil
@@ -1,7 +1,7 @@
 {{ file_header }}{% if view_controller_imports %}
 {% for import in view_controller_imports %}
 import {{ import }}{% endfor %}{% endif %}
-{% if view_state_publisher %}
+
 /**
  PURPOSE:
  The view state of your View Controller.
@@ -11,7 +11,7 @@ internal struct {{ node_name }}ViewState: Equatable, InitialStateProviding {
     /// The initial view state.
     internal static var initialState: {{ node_name }}ViewState = .init()
 }
-{% endif %}
+
 /**
  PURPOSE:
  The interface that the View will speak to the Context through. Used for informing the Context of
@@ -26,7 +26,7 @@ internal protocol {{ node_name }}Receiver: AnyObject {}{% endif %}
  PURPOSE:
  Concrete implementation of the UI.
  */
-internal final class {{ node_name }}ViewController: {{ view_controller_type }}{% if view_state_publisher %}, StateObserver{% endif %} {
+internal final class {{ node_name }}ViewController: {{ view_controller_type }}, StateObserver {
 {% if view_controller_properties %}
     {{ view_controller_properties|indent:4 }}
 {% endif %}
@@ -35,34 +35,31 @@ internal final class {{ node_name }}ViewController: {{ view_controller_type }}{%
 
     /// The Analytics instance.
     internal weak var analytics: {{ node_name }}Analytics?
-{% if view_state_publisher %}
+
     /// The collection of cancellable instances.
     private var cancellables: Set<{{ cancellable_type }}> = .init()
 
     /// The view state publisher.
     private let viewState: {{ publisher_type }}<{{ node_name }}ViewState{{ publisher_failure_type }}>
-{% endif %}
-    /// The initializer.{% if view_state_publisher %}
+
+    /// The initializer.
     /// - Parameter viewState: The view state publisher
     internal init(viewState: {{ publisher_type }}<{{ node_name }}ViewState{{ publisher_failure_type }}>) {
         self.viewState = viewState{% if view_state_operators %}
             {{ view_state_operators|indent:12 }}{% endif %}
         super.init({{ view_controller_super_parameters }})
-    }{% else %}
-    internal init() {
-        super.init({{ view_controller_super_parameters }})
-    }{% endif %}
+    }
 
     @available(*, unavailable)
     internal required init?(coder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
     }{% if view_controller_methods %}
 
-    {{ view_controller_methods|indent:4 }}{% endif %}{% if view_state_publisher %}
+    {{ view_controller_methods|indent:4 }}{% endif %}
 
     internal func update(with viewState: {{ node_name }}ViewState) {{ '{' }}{% if view_controller_update_comment %}
         {{ view_controller_update_comment|indent:8 }}{% endif %}
-    }{% endif %}
+    }
 }
 
 extension {{ node_name }}ViewController: {{ node_name }}ViewControllable {}


### PR DESCRIPTION
This was an oversight that should have been removed as part of the remove without view state template work.