### PR TITLE
Fix extra space appearing in dependency protocol in Nodes Xcode template

### DIFF
--- a/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/Builder-SwiftUI.stencil
+++ b/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/Builder-SwiftUI.stencil
@@ -12,8 +12,7 @@ internal protocol {{ node_name }}Flow: {{ view_controllable_flow_type }} {}
  PURPOSE:
  Declares the dependencies required by this Node that will be injected (not created by this Node itself).
  */{% if dependencies %}
-public protocol {{ node_name }}Dependency: Dependency {
-{% for dependency in dependencies %}
+public protocol {{ node_name }}Dependency: Dependency {{ '{' }}{% for dependency in dependencies %}
     var {{ dependency.name }}: {{ dependency.type }} { get }{% endfor %}
 }{% else %}
 public protocol {{ node_name }}Dependency: Dependency {}{% endif %}

--- a/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/Builder.stencil
+++ b/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/Builder.stencil
@@ -13,8 +13,7 @@ internal protocol {{ node_name }}Flow: Flow {}{% endif %}
  PURPOSE:
  Declares the dependencies required by this Node that will be injected (not created by this Node itself).
  */{% if dependencies %}
-public protocol {{ node_name }}Dependency: Dependency {
-{% for dependency in dependencies %}
+public protocol {{ node_name }}Dependency: Dependency {{ '{' }}{% for dependency in dependencies %}
     var {{ dependency.name }}: {{ dependency.type }} { get }{% endfor %}
 }{% else %}
 public protocol {{ node_name }}Dependency: Dependency {}{% endif %}

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit.txt
@@ -13,7 +13,6 @@ internal protocol <nodeName>Flow: <viewControllableFlowType> {}
  Declares the dependencies required by this Node that will be injected (not created by this Node itself).
  */
 public protocol <nodeName>Dependency: Dependency {
-
     var <dependenciesName>: <dependenciesType> { get }
 }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom.txt
@@ -13,7 +13,6 @@ internal protocol <nodeName>Flow: <viewControllableFlowType> {}
  Declares the dependencies required by this Node that will be injected (not created by this Node itself).
  */
 public protocol <nodeName>Dependency: Dependency {
-
     var <dependenciesName>: <dependenciesType> { get }
 }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-SwiftUI.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-SwiftUI.txt
@@ -13,7 +13,6 @@ internal protocol <nodeName>Flow: <viewControllableFlowType> {}
  Declares the dependencies required by this Node that will be injected (not created by this Node itself).
  */
 public protocol <nodeName>Dependency: Dependency {
-
     var <dependenciesName>: <dependenciesType> { get }
 }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit.txt
@@ -13,7 +13,6 @@ internal protocol <nodeName>Flow: <viewControllableFlowType> {}
  Declares the dependencies required by this Node that will be injected (not created by this Node itself).
  */
 public protocol <nodeName>Dependency: Dependency {
-
     var <dependenciesName>: <dependenciesType> { get }
 }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-AppKit.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-AppKit.txt
@@ -13,7 +13,6 @@ internal protocol RootFlow: <viewControllableFlowType> {}
  Declares the dependencies required by this Node that will be injected (not created by this Node itself).
  */
 public protocol RootDependency: Dependency {
-
     var <dependenciesName>: <dependenciesType> { get }
 }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-Custom.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-Custom.txt
@@ -13,7 +13,6 @@ internal protocol RootFlow: <viewControllableFlowType> {}
  Declares the dependencies required by this Node that will be injected (not created by this Node itself).
  */
 public protocol RootDependency: Dependency {
-
     var <dependenciesName>: <dependenciesType> { get }
 }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-SwiftUI.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-SwiftUI.txt
@@ -13,7 +13,6 @@ internal protocol RootFlow: <viewControllableFlowType> {}
  Declares the dependencies required by this Node that will be injected (not created by this Node itself).
  */
 public protocol RootDependency: Dependency {
-
     var <dependenciesName>: <dependenciesType> { get }
 }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-UIKit.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-UIKit.txt
@@ -13,7 +13,6 @@ internal protocol RootFlow: <viewControllableFlowType> {}
  Declares the dependencies required by this Node that will be injected (not created by this Node itself).
  */
 public protocol RootDependency: Dependency {
-
     var <dependenciesName>: <dependenciesType> { get }
 }
 

--- a/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder.txt
+++ b/Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder.txt
@@ -13,7 +13,6 @@ internal protocol <nodeName>Flow: Flow {}
  Declares the dependencies required by this Node that will be injected (not created by this Node itself).
  */
 public protocol <nodeName>Dependency: Dependency {
-
     var <dependenciesName>: <dependenciesType> { get }
 }
 


### PR DESCRIPTION
Fix extra space appearing in dependency protocol in Nodes Xcode template using ```{{ '{' }}```.
Will want to consider using ```trimBehavior``` environment setting in stencil.