### PR TITLE
Rename "viewControllable"  to "viewController"

### DIFF
--- a/Sources/Nodes/ViewControllable/UIKit/UIWindow+WindowViewControllable.swift
+++ b/Sources/Nodes/ViewControllable/UIKit/UIWindow+WindowViewControllable.swift
@@ -13,9 +13,9 @@ extension UIWindow: WindowViewControllable {
 
     /// Presents a ``ViewControllable`` instance.
     ///
-    /// - Parameter viewControllable: The ``ViewControllable`` instance to present.
-    public func present(_ viewControllable: ViewControllable) {
-        rootViewController = viewControllable._asUIViewController()
+    /// - Parameter viewController: The ``ViewControllable`` instance to present.
+    public func present(_ viewController: ViewControllable) {
+        rootViewController = viewController._asUIViewController()
         makeKeyAndVisible()
     }
 }

--- a/Sources/Nodes/ViewControllable/WindowViewControllable.swift
+++ b/Sources/Nodes/ViewControllable/WindowViewControllable.swift
@@ -17,8 +17,8 @@ public protocol WindowViewControllable: AnyObject {
 
     /// Presents a ``ViewControllable`` instance.
     ///
-    /// - Parameter viewControllable: The ``ViewControllable`` instance to present.
-    func present(_ viewControllable: ViewControllable)
+    /// - Parameter viewController: The ``ViewControllable`` instance to present.
+    func present(_ viewController: ViewControllable)
 }
 
 #endif

--- a/genesis.yml
+++ b/genesis.yml
@@ -579,8 +579,8 @@ files:
        an example.
        */
       internal protocol AppFlowInterface: Flow {
-          func attachScene(_ viewControllable: WindowSceneViewControllable)
-          func detachScene(_ viewControllable: WindowSceneViewControllable)
+          func attachScene(_ viewController: WindowSceneViewControllable)
+          func detachScene(_ viewController: WindowSceneViewControllable)
       }
 
       /**
@@ -690,16 +690,16 @@ files:
       extension AppFlowImp: AppFlow {}
       extension AppFlowImp: AppFlowInterface {
 
-          func attachScene(_ viewControllable: WindowSceneViewControllable) {
+          func attachScene(_ viewController: WindowSceneViewControllable) {
               let flow: SceneFlow = sceneBuilder.build(withListener: context,
-                                                       viewController: viewControllable)
+                                                       viewController: viewController)
               attach(starting: flow)
           }
 
-          func detachScene(_ viewControllable: WindowSceneViewControllable) {
+          func detachScene(_ viewController: WindowSceneViewControllable) {
               subFlows
                   .compactMap { $0 as? SceneFlow }
-                  .filter { $0.viewControllable === viewControllable }
+                  .filter { $0.viewControllable === viewController }
                   .forEach(detach)
           }
       }


### PR DESCRIPTION
Rename `viewControllable` variables, properties and arguments to `viewController`

This should include framework source code as well as the stencils.

And excluding only this specific `viewControllable` property …

https://github.com/TinderApp/Nodes/blob/main/Sources/XcodeTemplateGeneratorLibrary/Resources/Templates/Flow.stencil#L34