### PR TITLE
Delete snapshots recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,3 +89,7 @@ ifndef platform
 	$(error required variable: "platform")
 endif
 	@./bin/get-deployment-target "$(platform)"
+
+.PHONY: delete-snapshots
+delete-snapshots:
+	rm -rf Tests/XcodeTemplateGeneratorLibraryTests/__Snapshots__/*


### PR DESCRIPTION
Delete snapshot files to allow developers to quickly record new ones.
Usage ```make delete-snapshots```
