### PR TITLE
Configure empty_count SwiftLint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,9 @@ included:
 
 child_config: .swiftlint-rules.yml
 
+empty_count:
+  only_after_dot: true
+
 file_header:
   required_pattern: |
     \/\/
@@ -24,6 +27,3 @@ custom_rules:
       "GIVEN / WHEN / THEN" comments must be uppercase, without punctuation and both preceded and followed by an empty line.
     regex: |
       ((?<=\n) +\/\/ (Given|given|When|when|Then|then)(?= *\n))|((?<=\n) +[^ ]\/\/ (GIVEN|WHEN|THEN))|((?<=\n) +\/\/  +(GIVEN|WHEN|THEN))|((?<=[^\n]\n) +\/\/ (GIVEN|WHEN|THEN))|((?<=\n) +\/\/ (GIVEN|WHEN|THEN)(?!\n\n))
-
-empty_count:
-  only_after_dot: true


### PR DESCRIPTION
In order to guard count > 0 (See [here](https://github.com/TinderApp/Nodes/compare/remove-plurality-from-strings...explore-increase-test-coverage?expand=1)), we must disable `empty_count` locally or we can configure this rule.