### PR TITLE
Replace Flow with AnyObject as not needed

### DIFF
--- a/Sources/NodesXcodeTemplatesGenerator/Resources/Templates/Context.stencil
+++ b/Sources/NodesXcodeTemplatesGenerator/Resources/Templates/Context.stencil
@@ -18,11 +18,11 @@ internal protocol {{ node_name }}Listener: AnyObject {}
  an example.
  */
 {% if root_node %}
-internal protocol {{ node_name }}FlowInterface: Flow {
+internal protocol {{ node_name }}FlowInterface: AnyObject {
     func didBecomeReady()
 }
 {% else %}
-internal protocol {{ node_name }}FlowInterface: Flow {}
+internal protocol {{ node_name }}FlowInterface: AnyObject {}
 {% endif %}
 
 /**

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-0.txt
@@ -11,7 +11,7 @@ internal protocol <nodeName>Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol <nodeName>FlowInterface: Flow {}
+internal protocol <nodeName>FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-1.txt
@@ -13,7 +13,7 @@ internal protocol <nodeName>Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol <nodeName>FlowInterface: Flow {}
+internal protocol <nodeName>FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-2.txt
@@ -14,7 +14,7 @@ internal protocol <nodeName>Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol <nodeName>FlowInterface: Flow {}
+internal protocol <nodeName>FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-0.txt
@@ -11,7 +11,7 @@ internal protocol <nodeName>Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol <nodeName>FlowInterface: Flow {}
+internal protocol <nodeName>FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-1.txt
@@ -13,7 +13,7 @@ internal protocol <nodeName>Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol <nodeName>FlowInterface: Flow {}
+internal protocol <nodeName>FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-2.txt
@@ -14,7 +14,7 @@ internal protocol <nodeName>Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol <nodeName>FlowInterface: Flow {}
+internal protocol <nodeName>FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-SwiftUI-mockCount-0.txt
@@ -11,7 +11,7 @@ internal protocol <nodeName>Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol <nodeName>FlowInterface: Flow {}
+internal protocol <nodeName>FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-SwiftUI-mockCount-1.txt
@@ -13,7 +13,7 @@ internal protocol <nodeName>Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol <nodeName>FlowInterface: Flow {}
+internal protocol <nodeName>FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-SwiftUI-mockCount-2.txt
@@ -14,7 +14,7 @@ internal protocol <nodeName>Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol <nodeName>FlowInterface: Flow {}
+internal protocol <nodeName>FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-0.txt
@@ -11,7 +11,7 @@ internal protocol <nodeName>Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol <nodeName>FlowInterface: Flow {}
+internal protocol <nodeName>FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-1.txt
@@ -13,7 +13,7 @@ internal protocol <nodeName>Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol <nodeName>FlowInterface: Flow {}
+internal protocol <nodeName>FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-2.txt
@@ -14,7 +14,7 @@ internal protocol <nodeName>Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol <nodeName>FlowInterface: Flow {}
+internal protocol <nodeName>FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-AppKit-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-AppKit-mockCount-0.txt
@@ -11,7 +11,7 @@ internal protocol RootListener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol RootFlowInterface: Flow {
+internal protocol RootFlowInterface: AnyObject {
     func didBecomeReady()
 }
 

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-AppKit-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-AppKit-mockCount-1.txt
@@ -13,7 +13,7 @@ internal protocol RootListener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol RootFlowInterface: Flow {
+internal protocol RootFlowInterface: AnyObject {
     func didBecomeReady()
 }
 

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-AppKit-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-AppKit-mockCount-2.txt
@@ -14,7 +14,7 @@ internal protocol RootListener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol RootFlowInterface: Flow {
+internal protocol RootFlowInterface: AnyObject {
     func didBecomeReady()
 }
 

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-Custom-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-Custom-mockCount-0.txt
@@ -11,7 +11,7 @@ internal protocol RootListener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol RootFlowInterface: Flow {
+internal protocol RootFlowInterface: AnyObject {
     func didBecomeReady()
 }
 

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-Custom-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-Custom-mockCount-1.txt
@@ -13,7 +13,7 @@ internal protocol RootListener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol RootFlowInterface: Flow {
+internal protocol RootFlowInterface: AnyObject {
     func didBecomeReady()
 }
 

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-Custom-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-Custom-mockCount-2.txt
@@ -14,7 +14,7 @@ internal protocol RootListener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol RootFlowInterface: Flow {
+internal protocol RootFlowInterface: AnyObject {
     func didBecomeReady()
 }
 

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-SwiftUI-mockCount-0.txt
@@ -11,7 +11,7 @@ internal protocol RootListener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol RootFlowInterface: Flow {
+internal protocol RootFlowInterface: AnyObject {
     func didBecomeReady()
 }
 

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-SwiftUI-mockCount-1.txt
@@ -13,7 +13,7 @@ internal protocol RootListener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol RootFlowInterface: Flow {
+internal protocol RootFlowInterface: AnyObject {
     func didBecomeReady()
 }
 

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-SwiftUI-mockCount-2.txt
@@ -14,7 +14,7 @@ internal protocol RootListener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol RootFlowInterface: Flow {
+internal protocol RootFlowInterface: AnyObject {
     func didBecomeReady()
 }
 

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-UIKit-mockCount-0.txt
@@ -11,7 +11,7 @@ internal protocol RootListener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol RootFlowInterface: Flow {
+internal protocol RootFlowInterface: AnyObject {
     func didBecomeReady()
 }
 

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-UIKit-mockCount-1.txt
@@ -13,7 +13,7 @@ internal protocol RootListener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol RootFlowInterface: Flow {
+internal protocol RootFlowInterface: AnyObject {
     func didBecomeReady()
 }
 

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Context-UIKit-mockCount-2.txt
@@ -14,7 +14,7 @@ internal protocol RootListener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol RootFlowInterface: Flow {
+internal protocol RootFlowInterface: AnyObject {
     func didBecomeReady()
 }
 

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-0.txt
@@ -11,7 +11,7 @@ internal protocol <nodeName>Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol <nodeName>FlowInterface: Flow {}
+internal protocol <nodeName>FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-1.txt
@@ -13,7 +13,7 @@ internal protocol <nodeName>Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol <nodeName>FlowInterface: Flow {}
+internal protocol <nodeName>FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-2.txt
@@ -14,7 +14,7 @@ internal protocol <nodeName>Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol <nodeName>FlowInterface: Flow {}
+internal protocol <nodeName>FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-SwiftUI-xctemplate-___FILEBASENAME___Context-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-SwiftUI-xctemplate-___FILEBASENAME___Context-swift.txt
@@ -14,7 +14,7 @@ internal protocol ___VARIABLE_productName___Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
+internal protocol ___VARIABLE_productName___FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-UIKit-xctemplate-___FILEBASENAME___Context-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-UIKit-xctemplate-___FILEBASENAME___Context-swift.txt
@@ -14,7 +14,7 @@ internal protocol ___VARIABLE_productName___Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
+internal protocol ___VARIABLE_productName___FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-view-injected-xctemplate-___FILEBASENAME___Context-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-view-injected-xctemplate-___FILEBASENAME___Context-swift.txt
@@ -14,7 +14,7 @@ internal protocol ___VARIABLE_productName___Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
+internal protocol ___VARIABLE_productName___FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-SwiftUI-xctemplate-___FILEBASENAME___Context-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-SwiftUI-xctemplate-___FILEBASENAME___Context-swift.txt
@@ -14,7 +14,7 @@ internal protocol ___VARIABLE_productName___Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
+internal protocol ___VARIABLE_productName___FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-UIKit-xctemplate-___FILEBASENAME___Context-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-UIKit-xctemplate-___FILEBASENAME___Context-swift.txt
@@ -14,7 +14,7 @@ internal protocol ___VARIABLE_productName___Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
+internal protocol ___VARIABLE_productName___FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-view-injected-xctemplate-___FILEBASENAME___Context-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-view-injected-xctemplate-___FILEBASENAME___Context-swift.txt
@@ -14,7 +14,7 @@ internal protocol ___VARIABLE_productName___Listener: AnyObject {}
  The interface that the Context will speak to the Flow through. Used to initiate navigation as
  an example.
  */
-internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
+internal protocol ___VARIABLE_productName___FlowInterface: AnyObject {}
 
 /**
  PURPOSE:

--- a/genesis.yml
+++ b/genesis.yml
@@ -831,7 +831,7 @@ files:
        The interface that the Context will speak to the Flow through. Used to initiate navigation as
        an example.
        */
-      internal protocol AppFlowInterface: Flow {
+      internal protocol AppFlowInterface: AnyObject {
           func attachScene(_ viewController: WindowSceneViewControllable)
           func detachScene(_ viewController: WindowSceneViewControllable)
       }
@@ -1199,7 +1199,7 @@ files:
        The interface that the Context will speak to the Flow through. Used to initiate navigation as
        an example.
        */
-      internal protocol SceneFlowInterface: Flow {}
+      internal protocol SceneFlowInterface: AnyObject {}
 
       /**
        PURPOSE:
@@ -1550,7 +1550,7 @@ files:
        The interface that the Context will speak to the Flow through. Used to initiate navigation as
        an example.
        */
-      internal protocol WindowFlowInterface: Flow {}
+      internal protocol WindowFlowInterface: AnyObject {}
 
       /**
        PURPOSE:
@@ -1894,7 +1894,7 @@ files:
        The interface that the Context will speak to the Flow through. Used to initiate navigation as
        an example.
        */
-      internal protocol RootFlowInterface: Flow {
+      internal protocol RootFlowInterface: AnyObject {
           func didBecomeReady()
       }
 


### PR DESCRIPTION
This PR will change the FlowInterface conformance declaration from `Flow` to `AnyObject` in `Context.stencil` and `genesis.yml`. The Flow conformance declaration is not - and perhaps never was - needed.