### PR TITLE
Use disable/enable style for identifier_name rule

### DIFF
--- a/Sources/Nodes/ViewControllable/UIKit/NavigationControllable/NavigationControllable.swift
+++ b/Sources/Nodes/ViewControllable/UIKit/NavigationControllable/NavigationControllable.swift
@@ -37,10 +37,14 @@ public protocol NavigationControllable: ViewControllable {
     ///   - animated: A Boolean value specifying whether the navigation stack transition is animated.
     func pop(_ viewController: ViewControllable, animated: Bool)
 
+    // swiftlint:disable identifier_name
+
     /// Returns `self` as a ``UINavigationController``.
     ///
     /// - Returns: The `self` instance as a ``UINavigationController``.
-    func _asUINavigationController() -> UINavigationController // swiftlint:disable:this identifier_name
+    func _asUINavigationController() -> UINavigationController
+
+    // swiftlint:enable identifier_name
 }
 
 #endif

--- a/Sources/Nodes/ViewControllable/UIKit/NavigationControllable/UINavigationController+NavigationControllable.swift
+++ b/Sources/Nodes/ViewControllable/UIKit/NavigationControllable/UINavigationController+NavigationControllable.swift
@@ -45,12 +45,16 @@ extension UINavigationController: NavigationControllable {
         popViewController(animated: animated)
     }
 
+    // swiftlint:disable identifier_name
+
     /// Returns `self` as a ``UINavigationController``.
     ///
     /// - Returns: The `self` instance as a ``UINavigationController``.
-    public func _asUINavigationController() -> UINavigationController { // swiftlint:disable:this identifier_name
+    public func _asUINavigationController() -> UINavigationController {
         self
     }
+
+    // swiftlint:enable identifier_name
 }
 
 #endif

--- a/Sources/Nodes/ViewControllable/UIKit/TabBarControllable/TabBarControllable.swift
+++ b/Sources/Nodes/ViewControllable/UIKit/TabBarControllable/TabBarControllable.swift
@@ -26,10 +26,14 @@ public protocol TabBarControllable: ViewControllable {
         animated: Bool
     )
 
+    // swiftlint:disable identifier_name
+
     /// Returns `self` as a ``UITabBarController``.
     ///
     /// - Returns: The `self` instance as a ``UITabBarController``.
-    func _asUITabBarController() -> UITabBarController // swiftlint:disable:this identifier_name
+    func _asUITabBarController() -> UITabBarController
+
+    // swiftlint:enable identifier_name
 }
 
 #endif

--- a/Sources/Nodes/ViewControllable/UIKit/TabBarControllable/UITabBarController+TabBarControllable.swift
+++ b/Sources/Nodes/ViewControllable/UIKit/TabBarControllable/UITabBarController+TabBarControllable.swift
@@ -26,12 +26,16 @@ extension UITabBarController: TabBarControllable {
         setViewControllers(viewControllers?.map { $0._asUIViewController() }, animated: animated)
     }
 
+    // swiftlint:disable identifier_name
+
     /// Returns `self` as a ``UITabBarController``.
     ///
     /// - Returns: The `self` instance as a ``UITabBarController``.
-    public func _asUITabBarController() -> UITabBarController {  // swiftlint:disable:this identifier_name
+    public func _asUITabBarController() -> UITabBarController {
         self
     }
+
+    // swiftlint:enable identifier_name
 }
 
 #endif

--- a/Sources/Nodes/ViewControllable/UIKit/UIViewController+ModalStyle.swift
+++ b/Sources/Nodes/ViewControllable/UIKit/UIViewController+ModalStyle.swift
@@ -150,8 +150,10 @@ public struct ModalStyle {
              allowInteractiveDismissal: false)
     }
 
+    // swiftlint:disable identifier_name
+
     /// DEPRECATED - DO NOT USE
-    public func _withAdditionalConfiguration( // swiftlint:disable:this identifier_name
+    public func _withAdditionalConfiguration(
         configuration additionalConfiguration: @escaping (ViewControllable) -> Void
     ) -> Self {
         Self(behavior: behavior,
@@ -159,6 +161,8 @@ public struct ModalStyle {
              allowInteractiveDismissal: allowInteractiveDismissal,
              configuration: configuration + [additionalConfiguration])
     }
+
+    // swiftlint:enable identifier_name
 }
 
 extension UIViewController {

--- a/Sources/Nodes/ViewControllable/UIKit/UIViewController+ViewControllable.swift
+++ b/Sources/Nodes/ViewControllable/UIKit/UIViewController+ViewControllable.swift
@@ -68,12 +68,16 @@ extension UIViewController: ViewControllable {
         _removeChild(viewController)
     }
 
+    // swiftlint:disable identifier_name
+
     /// Returns `self` as a ``UIViewController``.
     ///
     /// - Returns: The `self` instance as a ``UIViewController``.
-    public func _asUIViewController() -> UIViewController { // swiftlint:disable:this identifier_name
+    public func _asUIViewController() -> UIViewController {
         self
     }
+
+    // swiftlint:enable identifier_name
 }
 
 #endif

--- a/Sources/Nodes/ViewControllable/ViewControllable.swift
+++ b/Sources/Nodes/ViewControllable/ViewControllable.swift
@@ -63,10 +63,14 @@ public protocol ViewControllable: AnyObject {
     /// - Parameter viewController: The ``ViewControllable`` instance to uncontain.
     func uncontain(_ viewController: ViewControllable)
 
+    // swiftlint:disable identifier_name
+
     /// Returns `self` as a ``UIViewController``.
     ///
     /// - Returns: The `self` instance as a ``UIViewController``.
-    func _asUIViewController() -> UIViewController // swiftlint:disable:this identifier_name
+    func _asUIViewController() -> UIViewController
+
+    // swiftlint:enable identifier_name
 }
 
 extension ViewControllable {


### PR DESCRIPTION
This change is made in preparation of adding `@mockable` to the various `ViewControllable` protocols in a subsequent PR.