### PR TITLE
Make component public

### DIFF
--- a/Sources/NodesXcodeTemplatesGenerator/Resources/Templates/Builder-SwiftUI.stencil
+++ b/Sources/NodesXcodeTemplatesGenerator/Resources/Templates/Builder-SwiftUI.stencil
@@ -48,7 +48,7 @@ internal typealias {{ node_name }}DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class {{ node_name }}Component: Component
+public final class {{ node_name }}Component: Component
 <
     {{ node_name }}Dependency
 > {

--- a/Sources/NodesXcodeTemplatesGenerator/Resources/Templates/Builder.stencil
+++ b/Sources/NodesXcodeTemplatesGenerator/Resources/Templates/Builder.stencil
@@ -56,7 +56,7 @@ internal typealias {{ node_name }}DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class {{ node_name }}Component: Component
+public final class {{ node_name }}Component: Component
 <
     {{ node_name }}Dependency
 > {

--- a/Sources/NodesXcodeTemplatesGenerator/Resources/Templates/Plugin.stencil
+++ b/Sources/NodesXcodeTemplatesGenerator/Resources/Templates/Plugin.stencil
@@ -16,7 +16,7 @@ public protocol {{ plugin_name }}PluginDependency: Dependency {}
  PURPOSE:
  Declares dependencies that are owned by this Plugin.
  */
-internal final class {{ plugin_name }}PluginComponent: Component
+public final class {{ plugin_name }}PluginComponent: Component
 <
     {{ plugin_name }}PluginDependency
 > {

--- a/Sources/NodesXcodeTemplatesGenerator/Resources/Templates/PluginList.stencil
+++ b/Sources/NodesXcodeTemplatesGenerator/Resources/Templates/PluginList.stencil
@@ -38,7 +38,7 @@ public protocol {{ plugin_list_name }}PluginListDependency: Dependency {}
  PURPOSE:
  Declares dependencies that are owned by this Plugin List.
  */
-internal final class {{ plugin_list_name }}PluginListComponent: Component
+public final class {{ plugin_list_name }}PluginListComponent: Component
 <
     {{ plugin_list_name }}PluginListDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-0.txt
@@ -34,7 +34,7 @@ internal typealias <nodeName>DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class <nodeName>Component: Component
+public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-1.txt
@@ -38,7 +38,7 @@ internal typealias <nodeName>DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class <nodeName>Component: Component
+public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-2.txt
@@ -40,7 +40,7 @@ internal typealias <nodeName>DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class <nodeName>Component: Component
+public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-0.txt
@@ -34,7 +34,7 @@ internal typealias <nodeName>DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class <nodeName>Component: Component
+public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-1.txt
@@ -38,7 +38,7 @@ internal typealias <nodeName>DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class <nodeName>Component: Component
+public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-2.txt
@@ -40,7 +40,7 @@ internal typealias <nodeName>DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class <nodeName>Component: Component
+public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-SwiftUI-mockCount-0.txt
@@ -34,7 +34,7 @@ internal typealias <nodeName>DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class <nodeName>Component: Component
+public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-SwiftUI-mockCount-1.txt
@@ -38,7 +38,7 @@ internal typealias <nodeName>DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class <nodeName>Component: Component
+public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-SwiftUI-mockCount-2.txt
@@ -40,7 +40,7 @@ internal typealias <nodeName>DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class <nodeName>Component: Component
+public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-0.txt
@@ -34,7 +34,7 @@ internal typealias <nodeName>DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class <nodeName>Component: Component
+public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-1.txt
@@ -38,7 +38,7 @@ internal typealias <nodeName>DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class <nodeName>Component: Component
+public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-2.txt
@@ -40,7 +40,7 @@ internal typealias <nodeName>DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class <nodeName>Component: Component
+public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-AppKit-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-AppKit-mockCount-0.txt
@@ -34,7 +34,7 @@ internal typealias RootDynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class RootComponent: Component
+public final class RootComponent: Component
 <
     RootDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-AppKit-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-AppKit-mockCount-1.txt
@@ -38,7 +38,7 @@ internal typealias RootDynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class RootComponent: Component
+public final class RootComponent: Component
 <
     RootDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-AppKit-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-AppKit-mockCount-2.txt
@@ -40,7 +40,7 @@ internal typealias RootDynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class RootComponent: Component
+public final class RootComponent: Component
 <
     RootDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-Custom-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-Custom-mockCount-0.txt
@@ -34,7 +34,7 @@ internal typealias RootDynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class RootComponent: Component
+public final class RootComponent: Component
 <
     RootDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-Custom-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-Custom-mockCount-1.txt
@@ -38,7 +38,7 @@ internal typealias RootDynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class RootComponent: Component
+public final class RootComponent: Component
 <
     RootDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-Custom-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-Custom-mockCount-2.txt
@@ -40,7 +40,7 @@ internal typealias RootDynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class RootComponent: Component
+public final class RootComponent: Component
 <
     RootDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-SwiftUI-mockCount-0.txt
@@ -34,7 +34,7 @@ internal typealias RootDynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class RootComponent: Component
+public final class RootComponent: Component
 <
     RootDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-SwiftUI-mockCount-1.txt
@@ -38,7 +38,7 @@ internal typealias RootDynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class RootComponent: Component
+public final class RootComponent: Component
 <
     RootDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-SwiftUI-mockCount-2.txt
@@ -40,7 +40,7 @@ internal typealias RootDynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class RootComponent: Component
+public final class RootComponent: Component
 <
     RootDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-UIKit-mockCount-0.txt
@@ -34,7 +34,7 @@ internal typealias RootDynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class RootComponent: Component
+public final class RootComponent: Component
 <
     RootDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-UIKit-mockCount-1.txt
@@ -38,7 +38,7 @@ internal typealias RootDynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class RootComponent: Component
+public final class RootComponent: Component
 <
     RootDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeRoot.Builder-UIKit-mockCount-2.txt
@@ -40,7 +40,7 @@ internal typealias RootDynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class RootComponent: Component
+public final class RootComponent: Component
 <
     RootDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-0.txt
@@ -34,7 +34,7 @@ internal typealias <nodeName>DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class <nodeName>Component: Component
+public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-1.txt
@@ -38,7 +38,7 @@ internal typealias <nodeName>DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class <nodeName>Component: Component
+public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-2.txt
@@ -40,7 +40,7 @@ internal typealias <nodeName>DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class <nodeName>Component: Component
+public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.mockCount-0.txt
@@ -10,7 +10,7 @@ public protocol <pluginName>PluginDependency: Dependency {}
  PURPOSE:
  Declares dependencies that are owned by this Plugin.
  */
-internal final class <pluginName>PluginComponent: Component
+public final class <pluginName>PluginComponent: Component
 <
     <pluginName>PluginDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.mockCount-1.txt
@@ -12,7 +12,7 @@ public protocol <pluginName>PluginDependency: Dependency {}
  PURPOSE:
  Declares dependencies that are owned by this Plugin.
  */
-internal final class <pluginName>PluginComponent: Component
+public final class <pluginName>PluginComponent: Component
 <
     <pluginName>PluginDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.mockCount-2.txt
@@ -13,7 +13,7 @@ public protocol <pluginName>PluginDependency: Dependency {}
  PURPOSE:
  Declares dependencies that are owned by this Plugin.
  */
-internal final class <pluginName>PluginComponent: Component
+public final class <pluginName>PluginComponent: Component
 <
     <pluginName>PluginDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.mockCount-0.txt
@@ -32,7 +32,7 @@ public protocol <pluginListName>PluginListDependency: Dependency {}
  PURPOSE:
  Declares dependencies that are owned by this Plugin List.
  */
-internal final class <pluginListName>PluginListComponent: Component
+public final class <pluginListName>PluginListComponent: Component
 <
     <pluginListName>PluginListDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.mockCount-1.txt
@@ -34,7 +34,7 @@ public protocol <pluginListName>PluginListDependency: Dependency {}
  PURPOSE:
  Declares dependencies that are owned by this Plugin List.
  */
-internal final class <pluginListName>PluginListComponent: Component
+public final class <pluginListName>PluginListComponent: Component
 <
     <pluginListName>PluginListDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.mockCount-2.txt
@@ -35,7 +35,7 @@ public protocol <pluginListName>PluginListDependency: Dependency {}
  PURPOSE:
  Declares dependencies that are owned by this Plugin List.
  */
-internal final class <pluginListName>PluginListComponent: Component
+public final class <pluginListName>PluginListComponent: Component
 <
     <pluginListName>PluginListDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.mockCount-0.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.mockCount-0.txt
@@ -10,7 +10,7 @@ public protocol <pluginName>PluginDependency: Dependency {}
  PURPOSE:
  Declares dependencies that are owned by this Plugin.
  */
-internal final class <pluginName>PluginComponent: Component
+public final class <pluginName>PluginComponent: Component
 <
     <pluginName>PluginDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.mockCount-1.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.mockCount-1.txt
@@ -12,7 +12,7 @@ public protocol <pluginName>PluginDependency: Dependency {}
  PURPOSE:
  Declares dependencies that are owned by this Plugin.
  */
-internal final class <pluginName>PluginComponent: Component
+public final class <pluginName>PluginComponent: Component
 <
     <pluginName>PluginDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.mockCount-2.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.mockCount-2.txt
@@ -13,7 +13,7 @@ public protocol <pluginName>PluginDependency: Dependency {}
  PURPOSE:
  Declares dependencies that are owned by this Plugin.
  */
-internal final class <pluginName>PluginComponent: Component
+public final class <pluginName>PluginComponent: Component
 <
     <pluginName>PluginDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-SwiftUI-xctemplate-___FILEBASENAME___Builder-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-SwiftUI-xctemplate-___FILEBASENAME___Builder-swift.txt
@@ -38,7 +38,7 @@ internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class ___VARIABLE_productName___Component: Component
+public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-UIKit-xctemplate-___FILEBASENAME___Builder-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-UIKit-xctemplate-___FILEBASENAME___Builder-swift.txt
@@ -38,7 +38,7 @@ internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class ___VARIABLE_productName___Component: Component
+public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-view-injected-xctemplate-___FILEBASENAME___Builder-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Node-view-injected-xctemplate-___FILEBASENAME___Builder-swift.txt
@@ -38,7 +38,7 @@ internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class ___VARIABLE_productName___Component: Component
+public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-List-for-Node-xctemplate-___FILEBASENAME___PluginList-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-List-for-Node-xctemplate-___FILEBASENAME___PluginList-swift.txt
@@ -35,7 +35,7 @@ public protocol ___VARIABLE_productName___PluginListDependency: Dependency {}
  PURPOSE:
  Declares dependencies that are owned by this Plugin List.
  */
-internal final class ___VARIABLE_productName___PluginListComponent: Component
+public final class ___VARIABLE_productName___PluginListComponent: Component
 <
     ___VARIABLE_productName___PluginListDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-for-Node-xctemplate-___FILEBASENAME___Plugin-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-for-Node-xctemplate-___FILEBASENAME___Plugin-swift.txt
@@ -13,7 +13,7 @@ public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
  PURPOSE:
  Declares dependencies that are owned by this Plugin.
  */
-internal final class ___VARIABLE_productName___PluginComponent: Component
+public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-xctemplate-___FILEBASENAME___Plugin-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Developer-Xcode-Templates-File-Templates-Nodes-Architecture-Framework-identifier-Plugin-xctemplate-___FILEBASENAME___Plugin-swift.txt
@@ -13,7 +13,7 @@ public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
  PURPOSE:
  Declares dependencies that are owned by this Plugin.
  */
-internal final class ___VARIABLE_productName___PluginComponent: Component
+public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-SwiftUI-xctemplate-___FILEBASENAME___Builder-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-SwiftUI-xctemplate-___FILEBASENAME___Builder-swift.txt
@@ -38,7 +38,7 @@ internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class ___VARIABLE_productName___Component: Component
+public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-UIKit-xctemplate-___FILEBASENAME___Builder-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-UIKit-xctemplate-___FILEBASENAME___Builder-swift.txt
@@ -38,7 +38,7 @@ internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class ___VARIABLE_productName___Component: Component
+public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-view-injected-xctemplate-___FILEBASENAME___Builder-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Node-view-injected-xctemplate-___FILEBASENAME___Builder-swift.txt
@@ -38,7 +38,7 @@ internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
  PURPOSE:
  Declares dependencies that are owned by this Node.
  */
-internal final class ___VARIABLE_productName___Component: Component
+public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-List-for-Node-xctemplate-___FILEBASENAME___PluginList-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-List-for-Node-xctemplate-___FILEBASENAME___PluginList-swift.txt
@@ -35,7 +35,7 @@ public protocol ___VARIABLE_productName___PluginListDependency: Dependency {}
  PURPOSE:
  Declares dependencies that are owned by this Plugin List.
  */
-internal final class ___VARIABLE_productName___PluginListComponent: Component
+public final class ___VARIABLE_productName___PluginListComponent: Component
 <
     ___VARIABLE_productName___PluginListDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-for-Node-xctemplate-___FILEBASENAME___Plugin-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-for-Node-xctemplate-___FILEBASENAME___Plugin-swift.txt
@@ -13,7 +13,7 @@ public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
  PURPOSE:
  Declares dependencies that are owned by this Plugin.
  */
-internal final class ___VARIABLE_productName___PluginComponent: Component
+public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {

--- a/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-xctemplate-___FILEBASENAME___Plugin-swift.txt
+++ b/Tests/NodesXcodeTemplatesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-xctemplate-___FILEBASENAME___Plugin-swift.txt
@@ -13,7 +13,7 @@ public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
  PURPOSE:
  Declares dependencies that are owned by this Plugin.
  */
-internal final class ___VARIABLE_productName___PluginComponent: Component
+public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {

--- a/genesis.yml
+++ b/genesis.yml
@@ -1041,7 +1041,7 @@ files:
        PURPOSE:
        Declares dependencies that are owned by this Node.
        */
-      internal final class SceneComponent: Component
+      public final class SceneComponent: Component
       <
           SceneDependency
       > {
@@ -1388,7 +1388,7 @@ files:
        PURPOSE:
        Declares dependencies that are owned by this Node.
        */
-      internal final class WindowComponent: Component
+      public final class WindowComponent: Component
       <
           WindowDependency
       > {
@@ -1728,7 +1728,7 @@ files:
        PURPOSE:
        Declares dependencies that are owned by this Node.
        */
-      internal final class RootComponent: Component
+      public final class RootComponent: Component
       <
           RootDependency
       > {


### PR DESCRIPTION
Change Component class from internal to public in Nodes Xcode templates to be compatible with the latest Needle version.