### PR TITLE
Added a tests template for Plugins

### DIFF
--- a/Sources/NodesXcodeTemplatesGenerator/Resources/Stencils/PluginTests.stencil
+++ b/Sources/NodesXcodeTemplatesGenerator/Resources/Stencils/PluginTests.stencil
@@ -37,6 +37,10 @@ final class {{ plugin_name }}PluginTests: XCTestCase {
     }
 
     func testOverride() {
+        {% if is_nimble_enabled %}
+        expect { self.plugin.override() } != nil
+        {% else %}
         XCTAssertNotNil(plugin.override())
+        {% endif %}
     }
 }


### PR DESCRIPTION
This adds an initial test template for plugins. It can be moved to a test target and will make it easier for developers to create tests when making a new Node.