### PR TITLE
Use includeState default value in PresetGenerator.swift

### DIFF
--- a/Sources/NodesGenerator/PresetGenerator.swift
+++ b/Sources/NodesGenerator/PresetGenerator.swift
@@ -48,7 +48,7 @@ public final class PresetGenerator {
                 isPeripheryCommentEnabled: config.isPeripheryCommentEnabled,
                 isNimbleEnabled: config.isNimbleEnabled
             )
-            output = try StencilRenderer().renderNodeViewInjected(context: context, includeState: false)
+            output = try StencilRenderer().renderNodeViewInjected(context: context)
         } else {
             let uiFramework: UIFramework = try config.uiFramework(for: .uiKit)
             let kind: UIFramework.Kind = uiFramework.kind
@@ -93,7 +93,7 @@ public final class PresetGenerator {
                 isPeripheryCommentEnabled: config.isPeripheryCommentEnabled,
                 isNimbleEnabled: config.isNimbleEnabled
             )
-            output = try StencilRenderer().renderNode(context: context, kind: kind, includeState: true)
+            output = try StencilRenderer().renderNode(context: context, kind: kind)
         }
         for (file, contents): (String, String) in output.sorted(by: { $0.key < $1.key }) {
             let url: URL = directory

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateAppPreset.Contents-AppState-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateAppPreset.Contents-AppState-swift.txt
@@ -1,0 +1,9 @@
+//
+//  Created by <author> on <date>.
+//
+
+/**
+ PURPOSE:
+ The state of the Node.
+ */
+internal struct AppState: Equatable {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateAppPreset.Writes.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateAppPreset.Writes.txt
@@ -1,4 +1,4 @@
-▿ 4 elements
+▿ 5 elements
   ▿ (2 elements)
     - path: "/AppAnalytics.swift"
     - atomically: true
@@ -10,4 +10,7 @@
     - atomically: true
   ▿ (2 elements)
     - path: "/AppFlow.swift"
+    - atomically: true
+  ▿ (2 elements)
+    - path: "/AppState.swift"
     - atomically: true

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateScenePreset.Contents-SceneState-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateScenePreset.Contents-SceneState-swift.txt
@@ -1,0 +1,9 @@
+//
+//  Created by <author> on <date>.
+//
+
+/**
+ PURPOSE:
+ The state of the Node.
+ */
+internal struct SceneState: Equatable {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateScenePreset.Writes.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateScenePreset.Writes.txt
@@ -1,4 +1,4 @@
-▿ 4 elements
+▿ 5 elements
   ▿ (2 elements)
     - path: "/SceneAnalytics.swift"
     - atomically: true
@@ -10,4 +10,7 @@
     - atomically: true
   ▿ (2 elements)
     - path: "/SceneFlow.swift"
+    - atomically: true
+  ▿ (2 elements)
+    - path: "/SceneState.swift"
     - atomically: true

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateWindowPreset.Contents-WindowState-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateWindowPreset.Contents-WindowState-swift.txt
@@ -1,0 +1,9 @@
+//
+//  Created by <author> on <date>.
+//
+
+/**
+ PURPOSE:
+ The state of the Node.
+ */
+internal struct WindowState: Equatable {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateWindowPreset.Writes.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateWindowPreset.Writes.txt
@@ -1,4 +1,4 @@
-▿ 4 elements
+▿ 5 elements
   ▿ (2 elements)
     - path: "/WindowAnalytics.swift"
     - atomically: true
@@ -10,4 +10,7 @@
     - atomically: true
   ▿ (2 elements)
     - path: "/WindowFlow.swift"
+    - atomically: true
+  ▿ (2 elements)
+    - path: "/WindowState.swift"
     - atomically: true


### PR DESCRIPTION
Explore branch:

https://github.com/TinderApp/Nodes/compare/main...explore/remove-include-state

- [x] **Use includeState default value in PresetGenerator**
- [ ] Use includeState default value in StencilRenderer
- [ ] Use includeState default value in permutation
- [ ] Remove includeState param from StencilTemplate
- [ ] Always render state property in Context.stencil
