### PR TITLE
Use includeState default value in StencilRenderer

### DIFF
--- a/Sources/NodesGenerator/StencilRenderer.swift
+++ b/Sources/NodesGenerator/StencilRenderer.swift
@@ -12,23 +12,19 @@ public final class StencilRenderer {
     public func renderNode(
         context: NodeStencilContext,
         kind: UIFramework.Kind,
-        includeState: Bool = true,
         includeTests: Bool = false
     ) throws -> [String: String] {
         let node: StencilTemplate.Node = .init(for: .variation(for: kind))
-        let stencils: [StencilTemplate] = node.stencils(includeState: includeState,
-                                                        includeTests: includeTests)
+        let stencils: [StencilTemplate] = node.stencils(includeTests: includeTests)
         return try render(stencils: stencils, with: context.dictionary)
     }
 
     public func renderNodeViewInjected(
         context: NodeViewInjectedStencilContext,
-        includeState: Bool = true,
         includeTests: Bool = false
     ) throws -> [String: String] {
         let nodeViewInjected: StencilTemplate.NodeViewInjected = .init()
-        let stencils: [StencilTemplate] = nodeViewInjected.stencils(includeState: includeState,
-                                                                    includeTests: includeTests)
+        let stencils: [StencilTemplate] = nodeViewInjected.stencils(includeTests: includeTests)
         return try render(stencils: stencils, with: context.dictionary)
     }
 

--- a/Tests/NodesGeneratorTests/StencilRendererTests.swift
+++ b/Tests/NodesGeneratorTests/StencilRendererTests.swift
@@ -68,13 +68,13 @@ final class StencilRendererTests: XCTestCase, TestFactories {
         try mockCounts.forEach { count in
             let context: NodeViewInjectedStencilContext = try givenNodeViewInjectedStencilContext(preset: .app,
                                                                                                   mockCount: count)
-            let templates: [String: String] = try stencilRenderer.renderNodeViewInjected(context: context,
-                                                                                         includeState: false)
+            let templates: [String: String] = try stencilRenderer.renderNodeViewInjected(context: context)
             expect(templates.keys.sorted()) == [
                 "Analytics",
                 "Builder",
                 "Context",
-                "Flow"
+                "Flow",
+                "State"
             ]
             templates.forEach { name, template in
                 assertSnapshot(of: template,
@@ -89,13 +89,13 @@ final class StencilRendererTests: XCTestCase, TestFactories {
         try mockCounts.forEach { count in
             let context: NodeViewInjectedStencilContext = try givenNodeViewInjectedStencilContext(preset: .scene,
                                                                                                   mockCount: count)
-            let templates: [String: String] = try stencilRenderer.renderNodeViewInjected(context: context,
-                                                                                         includeState: false)
+            let templates: [String: String] = try stencilRenderer.renderNodeViewInjected(context: context)
             expect(templates.keys.sorted()) == [
                 "Analytics",
                 "Builder",
                 "Context",
-                "Flow"
+                "Flow",
+                "State"
             ]
             templates.forEach { name, template in
                 assertSnapshot(of: template,
@@ -110,13 +110,13 @@ final class StencilRendererTests: XCTestCase, TestFactories {
         try mockCounts.forEach { count in
             let context: NodeViewInjectedStencilContext = try givenNodeViewInjectedStencilContext(preset: .window,
                                                                                                   mockCount: count)
-            let templates: [String: String] = try stencilRenderer.renderNodeViewInjected(context: context,
-                                                                                         includeState: false)
+            let templates: [String: String] = try stencilRenderer.renderNodeViewInjected(context: context)
             expect(templates.keys.sorted()) == [
                 "Analytics",
                 "Builder",
                 "Context",
-                "Flow"
+                "Flow",
+                "State"
             ]
             templates.forEach { name, template in
                 assertSnapshot(of: template,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-0.txt
@@ -1,0 +1,7 @@
+<fileHeader>
+
+/**
+ PURPOSE:
+ The state of the Node.
+ */
+internal struct AppState: Equatable {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-1.txt
@@ -1,0 +1,9 @@
+<fileHeader>
+
+import <stateImport>
+
+/**
+ PURPOSE:
+ The state of the Node.
+ */
+internal struct AppState: Equatable {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-2.txt
@@ -1,0 +1,10 @@
+<fileHeader>
+
+import <stateImport1>
+import <stateImport2>
+
+/**
+ PURPOSE:
+ The state of the Node.
+ */
+internal struct AppState: Equatable {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-0.txt
@@ -1,0 +1,7 @@
+<fileHeader>
+
+/**
+ PURPOSE:
+ The state of the Node.
+ */
+internal struct SceneState: Equatable {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-1.txt
@@ -1,0 +1,9 @@
+<fileHeader>
+
+import <stateImport>
+
+/**
+ PURPOSE:
+ The state of the Node.
+ */
+internal struct SceneState: Equatable {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-2.txt
@@ -1,0 +1,10 @@
+<fileHeader>
+
+import <stateImport1>
+import <stateImport2>
+
+/**
+ PURPOSE:
+ The state of the Node.
+ */
+internal struct SceneState: Equatable {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-0.txt
@@ -1,0 +1,7 @@
+<fileHeader>
+
+/**
+ PURPOSE:
+ The state of the Node.
+ */
+internal struct WindowState: Equatable {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-1.txt
@@ -1,0 +1,9 @@
+<fileHeader>
+
+import <stateImport>
+
+/**
+ PURPOSE:
+ The state of the Node.
+ */
+internal struct WindowState: Equatable {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-2.txt
@@ -1,0 +1,10 @@
+<fileHeader>
+
+import <stateImport1>
+import <stateImport2>
+
+/**
+ PURPOSE:
+ The state of the Node.
+ */
+internal struct WindowState: Equatable {}


### PR DESCRIPTION
Explore branch:

https://github.com/TinderApp/Nodes/compare/main...explore/remove-include-state

- [x] Use includeState default value in PresetGenerator
- [x] **Use includeState default value in StencilRenderer**
- [ ] Use includeState default value in permutation
- [ ] Remove includeState param from StencilTemplate
- [ ] Always render state property in Context.stencil
