### PR TITLE
Use includeState default value in permutation

### DIFF
--- a/Sources/NodesGenerator/XcodeTemplatePermutations/NodeXcodeTemplateV2Permutation.swift
+++ b/Sources/NodesGenerator/XcodeTemplatePermutations/NodeXcodeTemplateV2Permutation.swift
@@ -11,7 +11,7 @@ internal struct NodeXcodeTemplateV2Permutation: XcodeTemplatePermutation {
     internal init(usePluginList: Bool, for uiFramework: UIFramework, config: Config) {
         let node: StencilTemplate.Node = StencilTemplate.Node(for: .variation(for: uiFramework.kind))
         name = "\(usePluginList ? XcodeTemplateConstants.usePluginList : "")\(uiFramework.name)"
-        stencils = node.stencils(includeState: true, includeTests: config.isTestTemplatesGenerationEnabled)
+        stencils = node.stencils(includeTests: config.isTestTemplatesGenerationEnabled)
         // swiftlint:disable:next force_try
         stencilContext = try! NodeStencilContext(
             fileHeader: config.fileHeader,


### PR DESCRIPTION
Explore branch:

https://github.com/TinderApp/Nodes/compare/main...explore/remove-include-state

- [x] Use includeState default value in PresetGenerator
- [x] Use includeState default value in StencilRenderer
- [x] **Use includeState default value in permutation**
- [ ] Remove includeState param from StencilTemplate
- [ ] Always render state property in Context.stencil
