### PR TITLE
Always render state property in Context.stencil

### DIFF
--- a/Sources/NodesGenerator/Resources/Stencils/Context.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Context.stencil
@@ -67,7 +67,6 @@ internal final class {{ node_name }}ContextImp: AbstractContext {
     /// The Listener instance.
     internal weak var listener: {{ node_name }}Listener?
     {% endif %}
-    {% if node_name != "App" and node_name != "Scene" and node_name != "Window" %}
 
     {% if is_periphery_comment_enabled and not owns_view %}
     // periphery:ignore
@@ -75,7 +74,6 @@ internal final class {{ node_name }}ContextImp: AbstractContext {
     /// The State instance.
     @Published
     internal private(set) var state: {{ node_name }}State
-    {% endif %}
 
     {% if is_periphery_comment_enabled %}
     // periphery:ignore
@@ -102,7 +100,7 @@ internal final class {{ node_name }}ContextImp: AbstractContext {
     ) {
         {% if node_name == "Root" %}
         self.state = {{ node_name }}State(name: "{{ node_name }} View Controller")
-        {% elif node_name != "App" and node_name != "Scene" and node_name != "Window" %}
+        {% else %}
         self.state = {{ node_name }}State()
         {% endif %}
         self.analytics = analytics

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateAppPreset.Contents-AppContext-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateAppPreset.Contents-AppContext-swift.txt
@@ -30,6 +30,10 @@ internal final class AppContextImp: AbstractContext
     /// The Flow instance.
     internal weak var flow: AppFlowInterface?
 
+    /// The State instance.
+    @Published
+    internal private(set) var state: AppState
+
     /// The Analytics instance.
     private let analytics: AppAnalytics
 
@@ -44,6 +48,7 @@ internal final class AppContextImp: AbstractContext
         analytics: AppAnalytics,
         windowSceneState: AnyPublisher<WindowSceneState, Never>
     ) {
+        self.state = AppState()
         self.analytics = analytics
         self.windowSceneState = windowSceneState
         super.init(workers: workers)

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateScenePreset.Contents-SceneContext-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateScenePreset.Contents-SceneContext-swift.txt
@@ -38,6 +38,10 @@ internal final class SceneContextImp: AbstractContext
     /// The Listener instance.
     internal weak var listener: SceneListener?
 
+    /// The State instance.
+    @Published
+    internal private(set) var state: SceneState
+
     /// The Analytics instance.
     private let analytics: SceneAnalytics
 
@@ -49,6 +53,7 @@ internal final class SceneContextImp: AbstractContext
         workers: [Worker],
         analytics: SceneAnalytics
     ) {
+        self.state = SceneState()
         self.analytics = analytics
         super.init(workers: workers)
     }

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateWindowPreset.Contents-WindowContext-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateWindowPreset.Contents-WindowContext-swift.txt
@@ -38,6 +38,10 @@ internal final class WindowContextImp: AbstractContext
     /// The Listener instance.
     internal weak var listener: WindowListener?
 
+    /// The State instance.
+    @Published
+    internal private(set) var state: WindowState
+
     /// The Analytics instance.
     private let analytics: WindowAnalytics
 
@@ -49,6 +53,7 @@ internal final class WindowContextImp: AbstractContext
         workers: [Worker],
         analytics: WindowAnalytics
     ) {
+        self.state = WindowState()
         self.analytics = analytics
         super.init(workers: workers)
     }

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-0.txt
@@ -22,6 +22,10 @@ internal final class AppContextImp: AbstractContext {
     /// The Flow instance.
     internal weak var flow: AppFlowInterface?
 
+    /// The State instance.
+    @Published
+    internal private(set) var state: AppState
+
     /// The Analytics instance.
     private let analytics: AppAnalytics
 
@@ -36,6 +40,7 @@ internal final class AppContextImp: AbstractContext {
         analytics: AppAnalytics,
         windowSceneState: AnyPublisher<WindowSceneState, Never>
     ) {
+        self.state = AppState()
         self.analytics = analytics
         self.windowSceneState = windowSceneState
         super.init(workers: workers)

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-1.txt
@@ -29,6 +29,11 @@ internal final class AppContextImp: AbstractContext
     internal weak var flow: AppFlowInterface?
 
     // periphery:ignore
+    /// The State instance.
+    @Published
+    internal private(set) var state: AppState
+
+    // periphery:ignore
     /// The Analytics instance.
     private let analytics: AppAnalytics
 
@@ -43,6 +48,7 @@ internal final class AppContextImp: AbstractContext
         analytics: AppAnalytics,
         windowSceneState: AnyPublisher<WindowSceneState, Never>
     ) {
+        self.state = AppState()
         self.analytics = analytics
         self.windowSceneState = windowSceneState
         super.init(workers: workers)

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-2.txt
@@ -31,6 +31,11 @@ internal final class AppContextImp: AbstractContext
     internal weak var flow: AppFlowInterface?
 
     // periphery:ignore
+    /// The State instance.
+    @Published
+    internal private(set) var state: AppState
+
+    // periphery:ignore
     /// The Analytics instance.
     private let analytics: AppAnalytics
 
@@ -45,6 +50,7 @@ internal final class AppContextImp: AbstractContext
         analytics: AppAnalytics,
         windowSceneState: AnyPublisher<WindowSceneState, Never>
     ) {
+        self.state = AppState()
         self.analytics = analytics
         self.windowSceneState = windowSceneState
         super.init(workers: workers)

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-0.txt
@@ -30,6 +30,10 @@ internal final class SceneContextImp: AbstractContext {
     /// The Listener instance.
     internal weak var listener: SceneListener?
 
+    /// The State instance.
+    @Published
+    internal private(set) var state: SceneState
+
     /// The Analytics instance.
     private let analytics: SceneAnalytics
 
@@ -41,6 +45,7 @@ internal final class SceneContextImp: AbstractContext {
         workers: [Worker],
         analytics: SceneAnalytics
     ) {
+        self.state = SceneState()
         self.analytics = analytics
         super.init(workers: workers)
     }

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-1.txt
@@ -38,6 +38,11 @@ internal final class SceneContextImp: AbstractContext
     internal weak var listener: SceneListener?
 
     // periphery:ignore
+    /// The State instance.
+    @Published
+    internal private(set) var state: SceneState
+
+    // periphery:ignore
     /// The Analytics instance.
     private let analytics: SceneAnalytics
 
@@ -49,6 +54,7 @@ internal final class SceneContextImp: AbstractContext
         workers: [Worker],
         analytics: SceneAnalytics
     ) {
+        self.state = SceneState()
         self.analytics = analytics
         super.init(workers: workers)
     }

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-2.txt
@@ -40,6 +40,11 @@ internal final class SceneContextImp: AbstractContext
     internal weak var listener: SceneListener?
 
     // periphery:ignore
+    /// The State instance.
+    @Published
+    internal private(set) var state: SceneState
+
+    // periphery:ignore
     /// The Analytics instance.
     private let analytics: SceneAnalytics
 
@@ -51,6 +56,7 @@ internal final class SceneContextImp: AbstractContext
         workers: [Worker],
         analytics: SceneAnalytics
     ) {
+        self.state = SceneState()
         self.analytics = analytics
         super.init(workers: workers)
     }

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-0.txt
@@ -30,6 +30,10 @@ internal final class WindowContextImp: AbstractContext {
     /// The Listener instance.
     internal weak var listener: WindowListener?
 
+    /// The State instance.
+    @Published
+    internal private(set) var state: WindowState
+
     /// The Analytics instance.
     private let analytics: WindowAnalytics
 
@@ -41,6 +45,7 @@ internal final class WindowContextImp: AbstractContext {
         workers: [Worker],
         analytics: WindowAnalytics
     ) {
+        self.state = WindowState()
         self.analytics = analytics
         super.init(workers: workers)
     }

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-1.txt
@@ -38,6 +38,11 @@ internal final class WindowContextImp: AbstractContext
     internal weak var listener: WindowListener?
 
     // periphery:ignore
+    /// The State instance.
+    @Published
+    internal private(set) var state: WindowState
+
+    // periphery:ignore
     /// The Analytics instance.
     private let analytics: WindowAnalytics
 
@@ -49,6 +54,7 @@ internal final class WindowContextImp: AbstractContext
         workers: [Worker],
         analytics: WindowAnalytics
     ) {
+        self.state = WindowState()
         self.analytics = analytics
         super.init(workers: workers)
     }

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-2.txt
@@ -40,6 +40,11 @@ internal final class WindowContextImp: AbstractContext
     internal weak var listener: WindowListener?
 
     // periphery:ignore
+    /// The State instance.
+    @Published
+    internal private(set) var state: WindowState
+
+    // periphery:ignore
     /// The Analytics instance.
     private let analytics: WindowAnalytics
 
@@ -51,6 +56,7 @@ internal final class WindowContextImp: AbstractContext
         workers: [Worker],
         analytics: WindowAnalytics
     ) {
+        self.state = WindowState()
         self.analytics = analytics
         super.init(workers: workers)
     }


### PR DESCRIPTION
Explore branch:

https://github.com/TinderApp/Nodes/compare/main...explore/remove-include-state

- [x] Use includeState default value in PresetGenerator #637 
- [x] Use includeState default value in StencilRenderer #640 
- [x] Use includeState default value in permutation #641 
- [x] Remove includeState param from StencilTemplate #642 
- [x] **Always render state property in Context.stencil**
