### PR TITLE
Add PluginListTests to StencilTemplate

### DIFF
--- a/Sources/NodesGenerator/StencilTemplate.swift
+++ b/Sources/NodesGenerator/StencilTemplate.swift
@@ -19,6 +19,7 @@ public enum StencilTemplate: Equatable, CustomStringConvertible {
     case contextTests
     case flowTests
     case pluginTests
+    case pluginListTests
     case viewControllerTests(Variation)
     case viewStateFactoryTests
 
@@ -177,6 +178,8 @@ public enum StencilTemplate: Equatable, CustomStringConvertible {
             "FlowTests"
         case .pluginTests:
             "PluginTests"
+        case .pluginListTests:
+            "PluginListTests"
         case .viewControllerTests:
             "ViewControllerTests"
         case .viewStateFactoryTests:
@@ -190,7 +193,7 @@ public enum StencilTemplate: Equatable, CustomStringConvertible {
             description.appending(variation.rawValue)
         case .analytics, .context, .flow, .plugin, .pluginList, .state, .viewState, .worker:
             description
-        case .analyticsTests, .contextTests, .flowTests, .pluginTests, .viewStateFactoryTests:
+        case .analyticsTests, .contextTests, .flowTests, .pluginTests, .pluginListTests, .viewStateFactoryTests:
             description
         }
     }
@@ -245,6 +248,9 @@ public enum StencilTemplate: Equatable, CustomStringConvertible {
         case .flowTests:
             config.baseTestImports
         case .pluginTests:
+            config.baseTestImports
+                .union(["NodesTesting"])
+        case .pluginListTests:
             config.baseTestImports
                 .union(["NodesTesting"])
         case .viewControllerTests:

--- a/Tests/NodesGeneratorTests/StencilTemplateTests.swift
+++ b/Tests/NodesGeneratorTests/StencilTemplateTests.swift
@@ -70,6 +70,8 @@ final class StencilTemplateTests: XCTestCase, TestFactories {
                 expect(name) == "FlowTests"
             case .pluginTests:
                 expect(name) == "PluginTests"
+            case .pluginListTests:
+                expect(name) == "PluginListTests"
             case .viewControllerTests:
                 expect(name) == "ViewControllerTests"
             case .viewStateFactoryTests:
@@ -111,6 +113,8 @@ final class StencilTemplateTests: XCTestCase, TestFactories {
                 expect(filename) == "FlowTests"
             case .pluginTests:
                 expect(filename) == "PluginTests"
+            case .pluginListTests:
+                expect(filename) == "PluginListTests"
             case let .viewControllerTests(variation):
                 expect(filename) == "ViewControllerTests\(variation == .swiftUI ? "-SwiftUI" : "")"
             case .viewStateFactoryTests:
@@ -290,6 +294,11 @@ final class StencilTemplateTests: XCTestCase, TestFactories {
                         "NodesTesting",
                         "<baseTestImport>"
                     ]
+                case .pluginListTests:
+                    expect(imports) == [
+                        "NodesTesting",
+                        "<baseTestImport>"
+                    ]
                 case .viewControllerTests:
                     expect(imports) == [
                         "<baseTestImport>",
@@ -325,6 +334,7 @@ extension StencilTemplate {
         .contextTests,
         .flowTests,
         .pluginTests,
+        .pluginListTests,
         .viewControllerTests(.default),
         .viewControllerTests(.swiftUI),
         .viewStateFactoryTests


### PR DESCRIPTION
Explore branch: https://github.com/TinderApp/Nodes/compare/main...explore/add-plugin-list-test-template

- [x] Introduce PluginListTests.stencil
- [x] **Add PluginListTests to StencilTemplate**
- [ ] Add isNimbleEnabled to PluginListStencilContext
- [ ] Add pluginListTestsImports to stencil context
- [ ] Add PluginListTests to renderPluginList