### PR TITLE
Add isNimbleEnabled to WorkerStencilContext

### DIFF
--- a/Sources/NodesGenerator/StencilContexts/WorkerStencilContext.swift
+++ b/Sources/NodesGenerator/StencilContexts/WorkerStencilContext.swift
@@ -9,6 +9,7 @@ public struct WorkerStencilContext: StencilContext {
     private let workerImports: [String]
     private let workerGenericTypes: [String]
     private let isPeripheryCommentEnabled: Bool
+    private let isNimbleEnabled: Bool
 
     internal var dictionary: [String: Any] {
         [
@@ -16,7 +17,8 @@ public struct WorkerStencilContext: StencilContext {
             "worker_name": workerName,
             "worker_imports": workerImports,
             "worker_generic_types": workerGenericTypes,
-            "is_periphery_comment_enabled": isPeripheryCommentEnabled
+            "is_periphery_comment_enabled": isPeripheryCommentEnabled,
+            "is_nimble_enabled": isNimbleEnabled
         ]
     }
 
@@ -25,12 +27,14 @@ public struct WorkerStencilContext: StencilContext {
         workerName: String,
         workerImports: Set<String>,
         workerGenericTypes: [String],
-        isPeripheryCommentEnabled: Bool
+        isPeripheryCommentEnabled: Bool,
+        isNimbleEnabled: Bool
     ) {
         self.fileHeader = fileHeader
         self.workerName = workerName
         self.workerImports = workerImports.sortedImports()
         self.workerGenericTypes = workerGenericTypes
         self.isPeripheryCommentEnabled = isPeripheryCommentEnabled
+        self.isNimbleEnabled = isNimbleEnabled
     }
 }

--- a/Sources/NodesGenerator/XcodeTemplatePermutations/WorkerXcodeTemplatePermutation.swift
+++ b/Sources/NodesGenerator/XcodeTemplatePermutations/WorkerXcodeTemplatePermutation.swift
@@ -17,7 +17,8 @@ internal struct WorkerXcodeTemplatePermutation: XcodeTemplatePermutation {
             workerName: XcodeTemplateConstants.variable(XcodeTemplateConstants.productName),
             workerImports: worker.imports(with: config),
             workerGenericTypes: config.workerGenericTypes,
-            isPeripheryCommentEnabled: config.isPeripheryCommentEnabled
+            isPeripheryCommentEnabled: config.isPeripheryCommentEnabled,
+            isNimbleEnabled: config.isNimbleEnabled
         )
     }
 }

--- a/Tests/NodesGeneratorTests/Support/TestFactories.swift
+++ b/Tests/NodesGeneratorTests/Support/TestFactories.swift
@@ -251,7 +251,8 @@ extension TestFactories {
             workerName: "<workerName>",
             workerImports: .mock(with: "workerImport", count: mockCount),
             workerGenericTypes: .mock(with: "workerGenericType", count: mockCount),
-            isPeripheryCommentEnabled: mockCount > 0
+            isPeripheryCommentEnabled: mockCount > 0,
+            isNimbleEnabled: mockCount > 0
         )
     }
 }

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilContextsTests/testWorkerStencilContext.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilContextsTests/testWorkerStencilContext.1.txt
@@ -1,7 +1,10 @@
-▿ 5 key/value pairs
+▿ 6 key/value pairs
   ▿ (2 elements)
     - key: "file_header"
     - value: "<fileHeader>"
+  ▿ (2 elements)
+    - key: "is_nimble_enabled"
+    - value: true
   ▿ (2 elements)
     - key: "is_periphery_comment_enabled"
     - value: true

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testWorkerXcodeTemplatePermutation.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testWorkerXcodeTemplatePermutation.1.txt
@@ -2,6 +2,7 @@
   - name: "<name>"
   ▿ stencilContext: WorkerStencilContext
     - fileHeader: "<fileHeader>"
+    - isNimbleEnabled: false
     - isPeripheryCommentEnabled: false
     ▿ workerGenericTypes: 1 element
       - "<workerGenericType>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testWorkerXcodeTemplate.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testWorkerXcodeTemplate.1.txt
@@ -5,6 +5,7 @@
       - name: "Worker"
       ▿ stencilContext: WorkerStencilContext
         - fileHeader: "<fileHeader>"
+        - isNimbleEnabled: false
         - isPeripheryCommentEnabled: false
         ▿ workerGenericTypes: 1 element
           - "<workerGenericType>"


### PR DESCRIPTION
Explore branch: https://github.com/TinderApp/Nodes/compare/main...explore/add-worker-tests-stencil

- [x] Introduce WorkerTests.stencil
- [x] Add WorkerTests to StencilTemplate
- [x] **Add isNimbleEnabled to WorkerStencilContext**
- [ ] Add workerTestsImports to WorkerStencilContext
- [ ] Add WorkerTests to renderWorker