### PR TITLE
Update PluginTests as isEnabled defaults to true

### DIFF
--- a/Sources/NodesGenerator/Resources/Stencils/PluginTests.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/PluginTests.stencil
@@ -32,9 +32,9 @@ final class {{ plugin_name }}PluginTests: XCTestCase {
 
     func testCreate() {
         {% if is_nimble_enabled %}
-        expect { self.plugin.create() } == nil
+        expect { self.plugin.create() } != nil
         {% else %}
-        XCTAssertNil(plugin.create())
+        XCTAssertNotNil(plugin.create())
         {% endif %}
     }
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-AppKit-mockCount-0.txt
@@ -25,7 +25,7 @@ final class PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        XCTAssertNil(plugin.create())
+        XCTAssertNotNil(plugin.create())
     }
 
     func testOverride() {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-AppKit-mockCount-1.txt
@@ -25,7 +25,7 @@ final class PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        expect { self.plugin.create() } == nil
+        expect { self.plugin.create() } != nil
     }
 
     func testOverride() {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-AppKit-mockCount-2.txt
@@ -25,7 +25,7 @@ final class PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        expect { self.plugin.create() } == nil
+        expect { self.plugin.create() } != nil
     }
 
     func testOverride() {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-Custom-mockCount-0.txt
@@ -25,7 +25,7 @@ final class PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        XCTAssertNil(plugin.create())
+        XCTAssertNotNil(plugin.create())
     }
 
     func testOverride() {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-Custom-mockCount-1.txt
@@ -25,7 +25,7 @@ final class PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        expect { self.plugin.create() } == nil
+        expect { self.plugin.create() } != nil
     }
 
     func testOverride() {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-Custom-mockCount-2.txt
@@ -25,7 +25,7 @@ final class PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        expect { self.plugin.create() } == nil
+        expect { self.plugin.create() } != nil
     }
 
     func testOverride() {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-SwiftUI-mockCount-0.txt
@@ -25,7 +25,7 @@ final class PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        XCTAssertNil(plugin.create())
+        XCTAssertNotNil(plugin.create())
     }
 
     func testOverride() {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-SwiftUI-mockCount-1.txt
@@ -25,7 +25,7 @@ final class PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        expect { self.plugin.create() } == nil
+        expect { self.plugin.create() } != nil
     }
 
     func testOverride() {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-SwiftUI-mockCount-2.txt
@@ -25,7 +25,7 @@ final class PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        expect { self.plugin.create() } == nil
+        expect { self.plugin.create() } != nil
     }
 
     func testOverride() {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-UIKit-mockCount-0.txt
@@ -25,7 +25,7 @@ final class PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        XCTAssertNil(plugin.create())
+        XCTAssertNotNil(plugin.create())
     }
 
     func testOverride() {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-UIKit-mockCount-1.txt
@@ -25,7 +25,7 @@ final class PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        expect { self.plugin.create() } == nil
+        expect { self.plugin.create() } != nil
     }
 
     func testOverride() {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-UIKit-mockCount-2.txt
@@ -25,7 +25,7 @@ final class PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        expect { self.plugin.create() } == nil
+        expect { self.plugin.create() } != nil
     }
 
     func testOverride() {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.PluginTests-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.PluginTests-mockCount-0.txt
@@ -25,7 +25,7 @@ final class <pluginName>PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        XCTAssertNil(plugin.create())
+        XCTAssertNotNil(plugin.create())
     }
 
     func testOverride() {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.PluginTests-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.PluginTests-mockCount-1.txt
@@ -27,7 +27,7 @@ final class <pluginName>PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        expect { self.plugin.create() } == nil
+        expect { self.plugin.create() } != nil
     }
 
     func testOverride() {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.PluginTests-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.PluginTests-mockCount-2.txt
@@ -28,7 +28,7 @@ final class <pluginName>PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        expect { self.plugin.create() } == nil
+        expect { self.plugin.create() } != nil
     }
 
     func testOverride() {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.PluginTests-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.PluginTests-mockCount-0.txt
@@ -25,7 +25,7 @@ final class <pluginName>PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        XCTAssertNil(plugin.create())
+        XCTAssertNotNil(plugin.create())
     }
 
     func testOverride() {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.PluginTests-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.PluginTests-mockCount-1.txt
@@ -27,7 +27,7 @@ final class <pluginName>PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        expect { self.plugin.create() } == nil
+        expect { self.plugin.create() } != nil
     }
 
     func testOverride() {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.PluginTests-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.PluginTests-mockCount-2.txt
@@ -28,7 +28,7 @@ final class <pluginName>PluginTests: XCTestCase {
     }
 
     func testCreate() {
-        expect { self.plugin.create() } == nil
+        expect { self.plugin.create() } != nil
     }
 
     func testOverride() {


### PR DESCRIPTION
This is needed for v0.0.29.

Ideally this would have been done [here](https://github.com/TinderApp/Nodes/pull/638) but unfortunately we do not have tests to enforce this yet.