### PR TITLE
Remove file header from configuration

### DIFF
--- a/Customization/Configuration.md
+++ b/Customization/Configuration.md
@@ -31,7 +31,6 @@ All values shown in the samples below are the defaults.
 > TIP: It is only necessary to include config options that are different from the defaults.
 
 ```yaml
-fileHeader: //___FILEHEADER___
 baseImports: []
 baseTestImports:
   - Nimble

--- a/Sources/Executables/NodesCodeGenerator/NodesCodeGeneratorCommand.swift
+++ b/Sources/Executables/NodesCodeGenerator/NodesCodeGeneratorCommand.swift
@@ -28,7 +28,7 @@ internal struct NodesCodeGeneratorCommand: ParsableCommand {
         let config: Config = try configPath.flatMap { try Config(at: $0) } ?? Config()
         let dateFormatter: DateFormatter = .init()
         dateFormatter.dateStyle = .short
-        let fileHeader: String = "//\n//  Created by \(author) on \(dateFormatter.string(from: Date())).\n//"
+        let fileHeader: String = "\n//  Created by \(author) on \(dateFormatter.string(from: Date())).\n//"
         let directory: URL = .init(fileURLWithPath: outputPath)
         try PresetGenerator(config: config).generate(preset: preset, with: fileHeader, into: directory)
     }

--- a/Sources/NodesGenerator/Config.swift
+++ b/Sources/NodesGenerator/Config.swift
@@ -30,7 +30,6 @@ public struct Config: Equatable, Codable {
     }
 
     public var uiFrameworks: [UIFramework]
-    public var fileHeader: String
     public var baseImports: Set<String>
     public var baseTestImports: Set<String>
     public var reactiveImports: Set<String>
@@ -89,7 +88,6 @@ extension Config {
 
     public init() {
         uiFrameworks = [UIFramework(framework: .uiKit), UIFramework(framework: .swiftUI)]
-        fileHeader = "//___FILEHEADER___"
         baseImports = []
         baseTestImports = ["Nimble", "XCTest"]
         reactiveImports = ["Combine"]
@@ -149,9 +147,6 @@ extension Config {
             uiFrameworks = defaults.uiFrameworks
         }
 
-        fileHeader =
-            (try? decoder.decodeString(CodingKeys.fileHeader))
-            ?? defaults.fileHeader
         baseImports =
             (try? decoder.decode(CodingKeys.baseImports))
             ?? defaults.baseImports

--- a/Sources/NodesGenerator/Resources/Stencils/Analytics.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Analytics.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 {% if analytics_imports %}
 
 {% for import in analytics_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/AnalyticsTests.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/AnalyticsTests.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 {% if analytics_tests_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/Builder-SwiftUI.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Builder-SwiftUI.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 {% if builder_imports %}
 
 {% for import in builder_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/Builder.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Builder.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 {% if builder_imports %}
 
 {% for import in builder_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/Context.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Context.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 {% if context_imports %}
 
 {% for import in context_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/ContextTests.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/ContextTests.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 {% if context_tests_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/Flow.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Flow.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 {% if flow_imports %}
 
 {% for import in flow_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/FlowTests.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/FlowTests.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 {% if flow_tests_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/Plugin.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Plugin.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 {% if plugin_imports %}
 
 {% for import in plugin_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/PluginList.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/PluginList.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 {% if plugin_list_imports %}
 
 {% for import in plugin_list_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/PluginListTests.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/PluginListTests.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 {% if plugin_list_tests_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/PluginTests.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/PluginTests.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 {% if plugin_tests_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/State.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/State.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 {% if state_imports %}
 
 {% for import in state_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/ViewController-SwiftUI.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/ViewController-SwiftUI.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 {% if view_controller_imports %}
 
 {% for import in view_controller_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/ViewController.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/ViewController.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 {% if view_controller_imports %}
 
 {% for import in view_controller_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/ViewControllerTests-SwiftUI.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/ViewControllerTests-SwiftUI.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 {% if view_controller_tests_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/ViewControllerTests.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/ViewControllerTests.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 {% if view_controller_tests_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/ViewState.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/ViewState.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 {% if view_state_imports %}
 
 {% for import in view_state_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/ViewStateFactoryTests.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/ViewStateFactoryTests.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 {% if view_state_factory_tests_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/Worker.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Worker.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 {% if worker_imports %}
 
 {% for import in worker_imports %}

--- a/Sources/NodesGenerator/Resources/Stencils/WorkerTests.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/WorkerTests.stencil
@@ -1,4 +1,4 @@
-{{ file_header }}
+//{{ file_header }}
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 {% if worker_tests_imports %}

--- a/Sources/NodesGenerator/XcodeTemplateConstants.swift
+++ b/Sources/NodesGenerator/XcodeTemplateConstants.swift
@@ -5,6 +5,7 @@
 internal enum XcodeTemplateConstants {
 
     internal static let fileBaseName: String = "___FILEBASENAME___"
+    internal static let fileHeader: String = "___FILEHEADER___"
     internal static let productName: String = "productName"
     internal static let usePluginList: String = "usePluginList"
     internal static let pluginListName: String = "pluginListName"

--- a/Sources/NodesGenerator/XcodeTemplatePermutations/NodeViewInjectedXcodeTemplatePermutation.swift
+++ b/Sources/NodesGenerator/XcodeTemplatePermutations/NodeViewInjectedXcodeTemplatePermutation.swift
@@ -14,7 +14,7 @@ internal struct NodeViewInjectedXcodeTemplatePermutation: XcodeTemplatePermutati
         stencils = node.stencils(includeTests: config.isTestTemplatesGenerationEnabled)
         // swiftlint:disable:next force_try
         stencilContext = try! NodeViewInjectedStencilContext(
-            fileHeader: config.fileHeader,
+            fileHeader: XcodeTemplateConstants.fileHeader,
             nodeName: XcodeTemplateConstants.variable(XcodeTemplateConstants.productName),
             analyticsImports: node.analytics.imports(with: config),
             builderImports: node.builder.imports(with: config),

--- a/Sources/NodesGenerator/XcodeTemplatePermutations/NodeXcodeTemplatePermutation.swift
+++ b/Sources/NodesGenerator/XcodeTemplatePermutations/NodeXcodeTemplatePermutation.swift
@@ -14,7 +14,7 @@ internal struct NodeXcodeTemplatePermutation: XcodeTemplatePermutation {
         stencils = node.stencils(includePlugin: false, includeTests: config.isTestTemplatesGenerationEnabled)
         // swiftlint:disable:next force_try
         stencilContext = try! NodeStencilContext(
-            fileHeader: config.fileHeader,
+            fileHeader: XcodeTemplateConstants.fileHeader,
             nodeName: XcodeTemplateConstants.variable(XcodeTemplateConstants.productName),
             pluginName: "",
             pluginListName: "",

--- a/Sources/NodesGenerator/XcodeTemplatePermutations/NodeXcodeTemplateV2Permutation.swift
+++ b/Sources/NodesGenerator/XcodeTemplatePermutations/NodeXcodeTemplateV2Permutation.swift
@@ -15,7 +15,7 @@ internal struct NodeXcodeTemplateV2Permutation: XcodeTemplatePermutation {
         let productName: String = XcodeTemplateConstants.variable(XcodeTemplateConstants.productName)
         // swiftlint:disable:next force_try
         stencilContext = try! NodeStencilContext(
-            fileHeader: config.fileHeader,
+            fileHeader: XcodeTemplateConstants.fileHeader,
             nodeName: productName,
             pluginName: productName,
             pluginListName: usePluginList ? XcodeTemplateConstants.variable(XcodeTemplateConstants.pluginListName) : "",

--- a/Sources/NodesGenerator/XcodeTemplatePermutations/PluginListNodeXcodeTemplatePermutation.swift
+++ b/Sources/NodesGenerator/XcodeTemplatePermutations/PluginListNodeXcodeTemplatePermutation.swift
@@ -13,7 +13,7 @@ internal struct PluginListNodeXcodeTemplatePermutation: XcodeTemplatePermutation
         let pluginList: StencilTemplate = .pluginList
         stencils = [pluginList]
         stencilContext = PluginListStencilContext(
-            fileHeader: config.fileHeader,
+            fileHeader: XcodeTemplateConstants.fileHeader,
             pluginListName: XcodeTemplateConstants.variable(XcodeTemplateConstants.productName),
             pluginListImports: pluginList.imports(with: config),
             viewControllableFlowType: config.viewControllableFlowType,

--- a/Sources/NodesGenerator/XcodeTemplatePermutations/PluginNodeXcodeTemplatePermutation.swift
+++ b/Sources/NodesGenerator/XcodeTemplatePermutations/PluginNodeXcodeTemplatePermutation.swift
@@ -14,7 +14,7 @@ internal struct PluginNodeXcodeTemplatePermutation: XcodeTemplatePermutation {
         let pluginTests: StencilTemplate = .pluginTests
         stencils = [plugin] + (config.isTestTemplatesGenerationEnabled ? [pluginTests] : [])
         stencilContext = PluginStencilContext(
-            fileHeader: config.fileHeader,
+            fileHeader: XcodeTemplateConstants.fileHeader,
             pluginName: XcodeTemplateConstants.variable(XcodeTemplateConstants.productName),
             pluginImports: plugin.imports(with: config),
             pluginTestsImports: pluginTests.imports(with: config),

--- a/Sources/NodesGenerator/XcodeTemplatePermutations/PluginXcodeTemplatePermutation.swift
+++ b/Sources/NodesGenerator/XcodeTemplatePermutations/PluginXcodeTemplatePermutation.swift
@@ -14,7 +14,7 @@ internal struct PluginXcodeTemplatePermutation: XcodeTemplatePermutation {
         let pluginTests: StencilTemplate = .pluginTests
         stencils = [plugin] + (config.isTestTemplatesGenerationEnabled ? [pluginTests] : [])
         stencilContext = PluginStencilContext(
-            fileHeader: config.fileHeader,
+            fileHeader: XcodeTemplateConstants.fileHeader,
             pluginName: XcodeTemplateConstants.variable(XcodeTemplateConstants.productName),
             returnType: XcodeTemplateConstants.variable("returnType"),
             pluginImports: plugin.imports(with: config),

--- a/Sources/NodesGenerator/XcodeTemplatePermutations/WorkerXcodeTemplatePermutation.swift
+++ b/Sources/NodesGenerator/XcodeTemplatePermutations/WorkerXcodeTemplatePermutation.swift
@@ -13,7 +13,7 @@ internal struct WorkerXcodeTemplatePermutation: XcodeTemplatePermutation {
         let worker: StencilTemplate = .worker
         stencils = [worker]
         stencilContext = WorkerStencilContext(
-            fileHeader: config.fileHeader,
+            fileHeader: XcodeTemplateConstants.fileHeader,
             workerName: XcodeTemplateConstants.variable(XcodeTemplateConstants.productName),
             workerImports: worker.imports(with: config),
             workerGenericTypes: config.workerGenericTypes,

--- a/Tests/NodesGeneratorTests/ConfigTests.swift
+++ b/Tests/NodesGeneratorTests/ConfigTests.swift
@@ -148,7 +148,6 @@ final class ConfigTests: XCTestCase, TestFactories {
                 viewControllerSuperParameters: <viewControllerSuperParameters>
             viewControllerProperties: <viewControllerProperties-Custom>
             viewControllerMethods: <viewControllerMethods-Custom>
-        fileHeader: <fileHeader>
         baseImports:
           - <baseImports-1>
           - <baseImports-2>

--- a/Tests/NodesGeneratorTests/PresetGeneratorTests.swift
+++ b/Tests/NodesGeneratorTests/PresetGeneratorTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 final class PresetGeneratorTests: XCTestCase {
 
-    private let fileHeader: String = "//\n//  Created by <author> on <date>.\n//"
+    private let fileHeader: String = "\n//  Created by <author> on <date>.\n//"
 
     func testGenerateAppPreset() throws {
         let fileSystem: FileSystemMock = .init()

--- a/Tests/NodesGeneratorTests/Support/TestFactories.swift
+++ b/Tests/NodesGeneratorTests/Support/TestFactories.swift
@@ -26,7 +26,6 @@ extension TestFactories {
             uiFramework.viewControllerMethods = "<viewControllerMethods>"
             return uiFramework
         }
-        config.fileHeader = "<fileHeader>"
         config.baseImports = ["<baseImport>"]
         config.baseTestImports = ["<baseTestImport>"]
         config.reactiveImports = ["<reactiveImport>"]

--- a/Tests/NodesGeneratorTests/XcodeTemplateConstantsTests.swift
+++ b/Tests/NodesGeneratorTests/XcodeTemplateConstantsTests.swift
@@ -12,6 +12,10 @@ final class XcodeTemplateConstantsTests: XCTestCase {
         expect(XcodeTemplateConstants.fileBaseName) == "___FILEBASENAME___"
     }
 
+    func testFileHeader() {
+        expect(XcodeTemplateConstants.fileHeader) == "___FILEHEADER___"
+    }
+
     func testProductName() {
         expect(XcodeTemplateConstants.productName) == "productName"
     }

--- a/Tests/NodesGeneratorTests/__Snapshots__/ConfigTests/testConfig.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/ConfigTests/testConfig.1.txt
@@ -28,7 +28,6 @@
   ▿ dependencyInjectionImports: 2 members
     - "<dependencyInjectionImports-1>"
     - "<dependencyInjectionImports-2>"
-  - fileHeader: "<fileHeader>"
   ▿ flowImports: 2 members
     - "<flowImports-1>"
     - "<flowImports-2>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/ConfigTests/testConfigWithEmptyFileContents.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/ConfigTests/testConfigWithEmptyFileContents.1.txt
@@ -10,7 +10,6 @@
   - dependencies: 0 elements
   ▿ dependencyInjectionImports: 1 member
     - "NeedleFoundation"
-  - fileHeader: "//___FILEHEADER___"
   - flowImports: 0 members
   - flowProperties: 0 elements
   - isPeripheryCommentEnabled: false

--- a/Tests/NodesGeneratorTests/__Snapshots__/ConfigTests/testDecodingFromEmptyString.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/ConfigTests/testDecodingFromEmptyString.1.txt
@@ -10,7 +10,6 @@
   - dependencies: 0 elements
   ▿ dependencyInjectionImports: 1 member
     - "NeedleFoundation"
-  - fileHeader: "//___FILEHEADER___"
   - flowImports: 0 members
   - flowProperties: 0 elements
   - isPeripheryCommentEnabled: false

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport1>
 import <viewControllerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport1>
 import <viewControllerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport1>
 import <viewControllerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport1>
 import <viewControllerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport1>
 import <viewStateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport1>
 import <viewStateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport1>
 import <viewStateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport1>
 import <viewStateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Analytics-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Analytics-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Analytics-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Analytics-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Analytics-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Analytics-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Builder-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Builder-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Builder-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Flow-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Flow-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Flow-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Flow-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Flow-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Flow-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Analytics-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Analytics-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Analytics-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Analytics-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Analytics-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Analytics-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Builder-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Builder-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Builder-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Context-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Context-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Context-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Flow-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Flow-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Flow-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Flow-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Flow-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Flow-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.State-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.State-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.State-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewController-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewController-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewController-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewController-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewController-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewController-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport1>
 import <viewControllerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewState-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewState-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewState-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewState-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewState-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewState-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport1>
 import <viewStateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Analytics-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Analytics-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Analytics-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Analytics-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Analytics-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Analytics-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Builder-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Builder-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Builder-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Flow-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Flow-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Flow-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Flow-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Flow-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Flow-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Analytics-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Analytics-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Analytics-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Analytics-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Analytics-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Analytics-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Builder-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Builder-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Builder-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Flow-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Flow-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Flow-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Flow-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Flow-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Flow-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Analytics-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Analytics-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Analytics-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Analytics-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Analytics-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Analytics-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.AnalyticsTests-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.AnalyticsTests-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.AnalyticsTests-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.AnalyticsTests-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.AnalyticsTests-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.AnalyticsTests-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.ContextTests-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.ContextTests-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.ContextTests-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.ContextTests-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.ContextTests-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.ContextTests-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Flow-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Flow-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Flow-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Flow-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Flow-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Flow-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.FlowTests-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.FlowTests-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.FlowTests-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.FlowTests-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.FlowTests-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.FlowTests-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.State-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.State-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.State-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.State-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.State-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.State-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport1>
 import <viewControllerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport1>
 import <viewControllerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport1>
 import <viewControllerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport1>
 import <viewControllerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport1>
 import <viewStateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport1>
 import <viewStateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport1>
 import <viewStateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport1>
 import <viewStateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.AnalyticsTests-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ContextTests-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.FlowTests-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.PluginTests-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport1>
 import <viewControllerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport1>
 import <viewControllerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport1>
 import <viewControllerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport1>
 import <viewControllerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewControllerTests-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport1>
 import <viewStateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport1>
 import <viewStateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport1>
 import <viewStateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport1>
 import <viewStateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewStateFactoryTests-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /*
  INSTRUCTIONS:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <analyticsImport1>
 import <analyticsImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.AnalyticsTests-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <builderImport1>
 import <builderImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <contextImport1>
 import <contextImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ContextTests-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <flowImport1>
 import <flowImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.FlowTests-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <stateImport1>
 import <stateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport1>
 import <viewControllerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport1>
 import <viewControllerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport1>
 import <viewControllerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewControllerImport1>
 import <viewControllerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewControllerTests-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport1>
 import <viewStateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport1>
 import <viewStateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport1>
 import <viewStateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <viewStateImport1>
 import <viewStateImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-AppKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-AppKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-AppKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-Custom-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-Custom-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-Custom-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-SwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-SwiftUI-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-SwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-SwiftUI-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-SwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-SwiftUI-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-UIKit-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-UIKit-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewStateFactoryTests-UIKit-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.Plugin-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.Plugin-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.Plugin-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.Plugin-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <pluginImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.Plugin-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.Plugin-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <pluginImport1>
 import <pluginImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.PluginTests-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.PluginTests-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.PluginTests-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.PluginTests-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.PluginTests-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.PluginTests-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <pluginListImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <pluginListImport1>
 import <pluginListImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.Plugin-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.Plugin-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.Plugin-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.Plugin-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <pluginImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.Plugin-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.Plugin-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <pluginImport1>
 import <pluginImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.PluginTests-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.PluginTests-mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.PluginTests-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.PluginTests-mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.PluginTests-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginWithoutReturnType.PluginTests-mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker.mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker.mockCount-0.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 /**
  PURPOSE:

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker.mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker.mockCount-1.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <workerImport>
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker.mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker.mockCount-2.txt
@@ -1,4 +1,4 @@
-<fileHeader>
+//<fileHeader>
 
 import <workerImport1>
 import <workerImport2>

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeViewInjectedXcodeTemplatePermutation.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeViewInjectedXcodeTemplatePermutation.1.txt
@@ -35,7 +35,7 @@
         ▿ (2 elements)
           - key: "type"
           - value: "<dependencyType>"
-    - fileHeader: "<fileHeader>"
+    - fileHeader: "___FILEHEADER___"
     ▿ flowImports: 3 elements
       - "<baseImport>"
       - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.AppKit.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.AppKit.txt
@@ -35,7 +35,7 @@
         ▿ (2 elements)
           - key: "type"
           - value: "<dependencyType>"
-    - fileHeader: "<fileHeader>"
+    - fileHeader: "___FILEHEADER___"
     ▿ flowImports: 3 elements
       - "<baseImport>"
       - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.Custom.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.Custom.txt
@@ -35,7 +35,7 @@
         ▿ (2 elements)
           - key: "type"
           - value: "<dependencyType>"
-    - fileHeader: "<fileHeader>"
+    - fileHeader: "___FILEHEADER___"
     ▿ flowImports: 3 elements
       - "<baseImport>"
       - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.SwiftUI.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.SwiftUI.txt
@@ -35,7 +35,7 @@
         ▿ (2 elements)
           - key: "type"
           - value: "<dependencyType>"
-    - fileHeader: "<fileHeader>"
+    - fileHeader: "___FILEHEADER___"
     ▿ flowImports: 3 elements
       - "<baseImport>"
       - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.UIKit.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.UIKit.txt
@@ -35,7 +35,7 @@
         ▿ (2 elements)
           - key: "type"
           - value: "<dependencyType>"
-    - fileHeader: "<fileHeader>"
+    - fileHeader: "___FILEHEADER___"
     ▿ flowImports: 3 elements
       - "<baseImport>"
       - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplateV2Permutation.AppKit-UsePluginList.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplateV2Permutation.AppKit-UsePluginList.txt
@@ -35,7 +35,7 @@
         ▿ (2 elements)
           - key: "type"
           - value: "<dependencyType>"
-    - fileHeader: "<fileHeader>"
+    - fileHeader: "___FILEHEADER___"
     ▿ flowImports: 3 elements
       - "<baseImport>"
       - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplateV2Permutation.AppKit.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplateV2Permutation.AppKit.txt
@@ -35,7 +35,7 @@
         ▿ (2 elements)
           - key: "type"
           - value: "<dependencyType>"
-    - fileHeader: "<fileHeader>"
+    - fileHeader: "___FILEHEADER___"
     ▿ flowImports: 3 elements
       - "<baseImport>"
       - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplateV2Permutation.Custom-UsePluginList.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplateV2Permutation.Custom-UsePluginList.txt
@@ -35,7 +35,7 @@
         ▿ (2 elements)
           - key: "type"
           - value: "<dependencyType>"
-    - fileHeader: "<fileHeader>"
+    - fileHeader: "___FILEHEADER___"
     ▿ flowImports: 3 elements
       - "<baseImport>"
       - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplateV2Permutation.Custom.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplateV2Permutation.Custom.txt
@@ -35,7 +35,7 @@
         ▿ (2 elements)
           - key: "type"
           - value: "<dependencyType>"
-    - fileHeader: "<fileHeader>"
+    - fileHeader: "___FILEHEADER___"
     ▿ flowImports: 3 elements
       - "<baseImport>"
       - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplateV2Permutation.SwiftUI-UsePluginList.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplateV2Permutation.SwiftUI-UsePluginList.txt
@@ -35,7 +35,7 @@
         ▿ (2 elements)
           - key: "type"
           - value: "<dependencyType>"
-    - fileHeader: "<fileHeader>"
+    - fileHeader: "___FILEHEADER___"
     ▿ flowImports: 3 elements
       - "<baseImport>"
       - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplateV2Permutation.SwiftUI.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplateV2Permutation.SwiftUI.txt
@@ -35,7 +35,7 @@
         ▿ (2 elements)
           - key: "type"
           - value: "<dependencyType>"
-    - fileHeader: "<fileHeader>"
+    - fileHeader: "___FILEHEADER___"
     ▿ flowImports: 3 elements
       - "<baseImport>"
       - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplateV2Permutation.UIKit-UsePluginList.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplateV2Permutation.UIKit-UsePluginList.txt
@@ -35,7 +35,7 @@
         ▿ (2 elements)
           - key: "type"
           - value: "<dependencyType>"
-    - fileHeader: "<fileHeader>"
+    - fileHeader: "___FILEHEADER___"
     ▿ flowImports: 3 elements
       - "<baseImport>"
       - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplateV2Permutation.UIKit.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplateV2Permutation.UIKit.txt
@@ -35,7 +35,7 @@
         ▿ (2 elements)
           - key: "type"
           - value: "<dependencyType>"
-    - fileHeader: "<fileHeader>"
+    - fileHeader: "___FILEHEADER___"
     ▿ flowImports: 3 elements
       - "<baseImport>"
       - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testPluginListNodeXcodeTemplatePermutation.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testPluginListNodeXcodeTemplatePermutation.1.txt
@@ -1,7 +1,7 @@
 ▿ PluginListNodeXcodeTemplatePermutation
   - name: "<name>"
   ▿ stencilContext: PluginListStencilContext
-    - fileHeader: "<fileHeader>"
+    - fileHeader: "___FILEHEADER___"
     - isNimbleEnabled: false
     - isPeripheryCommentEnabled: false
     ▿ pluginListImports: 4 elements

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testPluginNodeXcodeTemplatePermutation.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testPluginNodeXcodeTemplatePermutation.1.txt
@@ -1,7 +1,7 @@
 ▿ PluginNodeXcodeTemplatePermutation
   - name: "<name>"
   ▿ stencilContext: PluginStencilContext
-    - fileHeader: "<fileHeader>"
+    - fileHeader: "___FILEHEADER___"
     - isNimbleEnabled: false
     - isPeripheryCommentEnabled: false
     ▿ pluginImports: 3 elements

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testPluginXcodeTemplatePermutation.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testPluginXcodeTemplatePermutation.1.txt
@@ -1,7 +1,7 @@
 ▿ PluginXcodeTemplatePermutation
   - name: "<name>"
   ▿ stencilContext: PluginStencilContext
-    - fileHeader: "<fileHeader>"
+    - fileHeader: "___FILEHEADER___"
     - isNimbleEnabled: false
     - isPeripheryCommentEnabled: false
     ▿ pluginImports: 3 elements

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testWorkerXcodeTemplatePermutation.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testWorkerXcodeTemplatePermutation.1.txt
@@ -1,7 +1,7 @@
 ▿ WorkerXcodeTemplatePermutation
   - name: "<name>"
   ▿ stencilContext: WorkerStencilContext
-    - fileHeader: "<fileHeader>"
+    - fileHeader: "___FILEHEADER___"
     - isNimbleEnabled: false
     - isPeripheryCommentEnabled: false
     ▿ workerGenericTypes: 1 element

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testNodeViewInjectedXcodeTemplate.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testNodeViewInjectedXcodeTemplate.1.txt
@@ -38,7 +38,7 @@
             ▿ (2 elements)
               - key: "type"
               - value: "<dependencyType>"
-        - fileHeader: "<fileHeader>"
+        - fileHeader: "___FILEHEADER___"
         ▿ flowImports: 3 elements
           - "<baseImport>"
           - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testNodeXcodeTemplate.AppKit.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testNodeXcodeTemplate.AppKit.txt
@@ -38,7 +38,7 @@
             ▿ (2 elements)
               - key: "type"
               - value: "<dependencyType>"
-        - fileHeader: "<fileHeader>"
+        - fileHeader: "___FILEHEADER___"
         ▿ flowImports: 3 elements
           - "<baseImport>"
           - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testNodeXcodeTemplate.Custom.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testNodeXcodeTemplate.Custom.txt
@@ -38,7 +38,7 @@
             ▿ (2 elements)
               - key: "type"
               - value: "<dependencyType>"
-        - fileHeader: "<fileHeader>"
+        - fileHeader: "___FILEHEADER___"
         ▿ flowImports: 3 elements
           - "<baseImport>"
           - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testNodeXcodeTemplate.SwiftUI.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testNodeXcodeTemplate.SwiftUI.txt
@@ -38,7 +38,7 @@
             ▿ (2 elements)
               - key: "type"
               - value: "<dependencyType>"
-        - fileHeader: "<fileHeader>"
+        - fileHeader: "___FILEHEADER___"
         ▿ flowImports: 3 elements
           - "<baseImport>"
           - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testNodeXcodeTemplate.UIKit.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testNodeXcodeTemplate.UIKit.txt
@@ -38,7 +38,7 @@
             ▿ (2 elements)
               - key: "type"
               - value: "<dependencyType>"
-        - fileHeader: "<fileHeader>"
+        - fileHeader: "___FILEHEADER___"
         ▿ flowImports: 3 elements
           - "<baseImport>"
           - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testNodeXcodeTemplateV2.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testNodeXcodeTemplateV2.1.txt
@@ -39,7 +39,7 @@
               ▿ (2 elements)
                 - key: "type"
                 - value: "<dependencyType>"
-          - fileHeader: "<fileHeader>"
+          - fileHeader: "___FILEHEADER___"
           ▿ flowImports: 3 elements
             - "<baseImport>"
             - "<flowImport>"
@@ -149,7 +149,7 @@
               ▿ (2 elements)
                 - key: "type"
                 - value: "<dependencyType>"
-          - fileHeader: "<fileHeader>"
+          - fileHeader: "___FILEHEADER___"
           ▿ flowImports: 3 elements
             - "<baseImport>"
             - "<flowImport>"
@@ -259,7 +259,7 @@
               ▿ (2 elements)
                 - key: "type"
                 - value: "<dependencyType>"
-          - fileHeader: "<fileHeader>"
+          - fileHeader: "___FILEHEADER___"
           ▿ flowImports: 3 elements
             - "<baseImport>"
             - "<flowImport>"
@@ -369,7 +369,7 @@
               ▿ (2 elements)
                 - key: "type"
                 - value: "<dependencyType>"
-          - fileHeader: "<fileHeader>"
+          - fileHeader: "___FILEHEADER___"
           ▿ flowImports: 3 elements
             - "<baseImport>"
             - "<flowImport>"
@@ -479,7 +479,7 @@
               ▿ (2 elements)
                 - key: "type"
                 - value: "<dependencyType>"
-          - fileHeader: "<fileHeader>"
+          - fileHeader: "___FILEHEADER___"
           ▿ flowImports: 3 elements
             - "<baseImport>"
             - "<flowImport>"
@@ -589,7 +589,7 @@
               ▿ (2 elements)
                 - key: "type"
                 - value: "<dependencyType>"
-          - fileHeader: "<fileHeader>"
+          - fileHeader: "___FILEHEADER___"
           ▿ flowImports: 3 elements
             - "<baseImport>"
             - "<flowImport>"
@@ -699,7 +699,7 @@
               ▿ (2 elements)
                 - key: "type"
                 - value: "<dependencyType>"
-          - fileHeader: "<fileHeader>"
+          - fileHeader: "___FILEHEADER___"
           ▿ flowImports: 3 elements
             - "<baseImport>"
             - "<flowImport>"
@@ -809,7 +809,7 @@
               ▿ (2 elements)
                 - key: "type"
                 - value: "<dependencyType>"
-          - fileHeader: "<fileHeader>"
+          - fileHeader: "___FILEHEADER___"
           ▿ flowImports: 3 elements
             - "<baseImport>"
             - "<flowImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testPluginListNodeXcodeTemplate.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testPluginListNodeXcodeTemplate.1.txt
@@ -4,7 +4,7 @@
     ▿ PluginListNodeXcodeTemplatePermutation
       - name: "Plugin List (for Node)"
       ▿ stencilContext: PluginListStencilContext
-        - fileHeader: "<fileHeader>"
+        - fileHeader: "___FILEHEADER___"
         - isNimbleEnabled: false
         - isPeripheryCommentEnabled: false
         ▿ pluginListImports: 4 elements

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testPluginNodeXcodeTemplate.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testPluginNodeXcodeTemplate.1.txt
@@ -4,7 +4,7 @@
     ▿ PluginNodeXcodeTemplatePermutation
       - name: "Plugin (for Node)"
       ▿ stencilContext: PluginStencilContext
-        - fileHeader: "<fileHeader>"
+        - fileHeader: "___FILEHEADER___"
         - isNimbleEnabled: false
         - isPeripheryCommentEnabled: false
         ▿ pluginImports: 3 elements

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testPluginXcodeTemplate.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testPluginXcodeTemplate.1.txt
@@ -4,7 +4,7 @@
     ▿ PluginXcodeTemplatePermutation
       - name: "Plugin"
       ▿ stencilContext: PluginStencilContext
-        - fileHeader: "<fileHeader>"
+        - fileHeader: "___FILEHEADER___"
         - isNimbleEnabled: false
         - isPeripheryCommentEnabled: false
         ▿ pluginImports: 3 elements

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testWorkerXcodeTemplate.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testWorkerXcodeTemplate.1.txt
@@ -4,7 +4,7 @@
     ▿ WorkerXcodeTemplatePermutation
       - name: "Worker"
       ▿ stencilContext: WorkerStencilContext
-        - fileHeader: "<fileHeader>"
+        - fileHeader: "___FILEHEADER___"
         - isNimbleEnabled: false
         - isPeripheryCommentEnabled: false
         ▿ workerGenericTypes: 1 element


### PR DESCRIPTION
- Leading slashes (`//`) are enforced to be consistent with default Xcode behavior.