### PR TITLE
Add pluginListTests to permutation stencils

### DIFF
--- a/Sources/NodesGenerator/XcodeTemplatePermutations/PluginListNodeXcodeTemplatePermutation.swift
+++ b/Sources/NodesGenerator/XcodeTemplatePermutations/PluginListNodeXcodeTemplatePermutation.swift
@@ -11,7 +11,8 @@ internal struct PluginListNodeXcodeTemplatePermutation: XcodeTemplatePermutation
     internal init(name: String, config: Config) {
         self.name = name
         let pluginList: StencilTemplate = .pluginList
-        stencils = [pluginList]
+        let pluginListTests: StencilTemplate = .pluginListTests
+        stencils = [pluginList] + (config.isTestTemplatesGenerationEnabled ? [pluginListTests] : [])
         stencilContext = PluginListStencilContext(
             fileHeader: config.fileHeader,
             pluginListName: XcodeTemplateConstants.variable(XcodeTemplateConstants.productName),

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Plugin-List-for-Node-PluginListTests.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Plugin-List-for-Node-PluginListTests.txt
@@ -1,0 +1,38 @@
+//___FILEHEADER___
+
+#warning("Manually move this test file to the corresponding test target then delete this warning.")
+
+@MainActor
+final class ___VARIABLE_productName___PluginListTests: XCTestCase {
+
+    private var pluginList: ___VARIABLE_productName___PluginListImp!
+
+    override func setUp() {
+        super.setUp()
+        pluginList = ___VARIABLE_productName___PluginListImp(componentFactory: injectComponent { parent in
+            ___VARIABLE_productName___PluginListComponent(parent: parent)
+        } with: {
+            // swiftlint:disable:next direct_return
+            let dependency: ___VARIABLE_productName___PluginListDependencyMock = .init()
+            // dependency.<dependencyName> = <dependencyName>Mock
+            return dependency
+        })
+    }
+
+    override func tearDown() {
+        pluginList = nil
+        super.tearDown()
+    }
+
+    func testCreateAll() {
+        expect { self.pluginList.createAll() }.to(beEmpty())
+    }
+
+    func testCreate() {
+        expect { self.pluginList.create() } == nil
+    }
+
+    func testCreateWithKey() {
+        expect { self.pluginList.create(key: "<key>") } == nil
+    }
+}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Writes.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Writes.txt
@@ -1,4 +1,4 @@
-▿ 184 elements
+▿ 185 elements
   ▿ (2 elements)
     - path: "/Developer/Xcode/Templates/File Templates/Nodes Architecture Framework (identifier)/Node - AppKit.xctemplate/___FILEBASENAME___Analytics.swift"
     - atomically: true
@@ -523,6 +523,9 @@
     - atomically: true
   ▿ (2 elements)
     - path: "/Developer/Xcode/Templates/File Templates/Nodes Architecture Framework (identifier)/Plugin List (for Node).xctemplate/___FILEBASENAME___PluginList.swift"
+    - atomically: true
+  ▿ (2 elements)
+    - path: "/Developer/Xcode/Templates/File Templates/Nodes Architecture Framework (identifier)/Plugin List (for Node).xctemplate/___FILEBASENAME___PluginListTests.swift"
     - atomically: true
   ▿ (2 elements)
     - path: "/Developer/Xcode/Templates/File Templates/Nodes Architecture Framework (identifier)/Plugin List (for Node).xctemplate/TemplateInfo.plist"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-List-for-Node-PluginListTests.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-List-for-Node-PluginListTests.txt
@@ -1,0 +1,38 @@
+//___FILEHEADER___
+
+#warning("Manually move this test file to the corresponding test target then delete this warning.")
+
+@MainActor
+final class ___VARIABLE_productName___PluginListTests: XCTestCase {
+
+    private var pluginList: ___VARIABLE_productName___PluginListImp!
+
+    override func setUp() {
+        super.setUp()
+        pluginList = ___VARIABLE_productName___PluginListImp(componentFactory: injectComponent { parent in
+            ___VARIABLE_productName___PluginListComponent(parent: parent)
+        } with: {
+            // swiftlint:disable:next direct_return
+            let dependency: ___VARIABLE_productName___PluginListDependencyMock = .init()
+            // dependency.<dependencyName> = <dependencyName>Mock
+            return dependency
+        })
+    }
+
+    override func tearDown() {
+        pluginList = nil
+        super.tearDown()
+    }
+
+    func testCreateAll() {
+        expect { self.pluginList.createAll() }.to(beEmpty())
+    }
+
+    func testCreate() {
+        expect { self.pluginList.create() } == nil
+    }
+
+    func testCreateWithKey() {
+        expect { self.pluginList.create(key: "<key>") } == nil
+    }
+}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Writes.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Writes.txt
@@ -1,4 +1,4 @@
-▿ 184 elements
+▿ 185 elements
   ▿ (2 elements)
     - path: "/Node - AppKit.xctemplate/___FILEBASENAME___Analytics.swift"
     - atomically: true
@@ -523,6 +523,9 @@
     - atomically: true
   ▿ (2 elements)
     - path: "/Plugin List (for Node).xctemplate/___FILEBASENAME___PluginList.swift"
+    - atomically: true
+  ▿ (2 elements)
+    - path: "/Plugin List (for Node).xctemplate/___FILEBASENAME___PluginListTests.swift"
     - atomically: true
   ▿ (2 elements)
     - path: "/Plugin List (for Node).xctemplate/TemplateInfo.plist"


### PR DESCRIPTION
Explore branch: https://github.com/TinderApp/Nodes/compare/main...explore/add-plugin-list-test-template

- [x] Introduce PluginListTests.stencil
- [x] Add PluginListTests to StencilTemplate
- [x] Add isNimbleEnabled to PluginListStencilContext
- [x] Add pluginListTestsImports to stencil context
- [ ] **Add pluginListTests to permutation stencils**
- [ ] Inject pluginListTestsImports into permutation context 
- [ ] Add PluginListTests to renderPluginList