### PR TITLE
Inject pluginListTestsImports into context

### DIFF
--- a/Sources/NodesGenerator/XcodeTemplatePermutations/PluginListNodeXcodeTemplatePermutation.swift
+++ b/Sources/NodesGenerator/XcodeTemplatePermutations/PluginListNodeXcodeTemplatePermutation.swift
@@ -17,7 +17,7 @@ internal struct PluginListNodeXcodeTemplatePermutation: XcodeTemplatePermutation
             fileHeader: XcodeTemplateConstants.fileHeader,
             pluginListName: XcodeTemplateConstants.variable(XcodeTemplateConstants.productName),
             pluginListImports: pluginList.imports(with: config),
-            pluginListTestsImports: [],
+            pluginListTestsImports: pluginListTests.imports(with: config),
             viewControllableFlowType: config.viewControllableFlowType,
             isPeripheryCommentEnabled: config.isPeripheryCommentEnabled,
             isNimbleEnabled: config.isNimbleEnabled

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testPluginListNodeXcodeTemplatePermutation.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testPluginListNodeXcodeTemplatePermutation.1.txt
@@ -10,7 +10,9 @@
       - "<pluginListImport>"
       - "Nodes"
     - pluginListName: "___VARIABLE_productName___"
-    - pluginListTestsImports: 0 elements
+    ▿ pluginListTestsImports: 2 elements
+      - "<baseTestImport>"
+      - "NodesTesting"
     - viewControllableFlowType: "<viewControllableFlowType>"
   ▿ stencils: 1 element
     - PluginList

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testPluginListNodeXcodeTemplate.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testPluginListNodeXcodeTemplate.1.txt
@@ -13,7 +13,9 @@
           - "<pluginListImport>"
           - "Nodes"
         - pluginListName: "___VARIABLE_productName___"
-        - pluginListTestsImports: 0 elements
+        ▿ pluginListTestsImports: 2 elements
+          - "<baseTestImport>"
+          - "NodesTesting"
         - viewControllableFlowType: "<viewControllableFlowType>"
       ▿ stencils: 1 element
         - PluginList

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Plugin-List-for-Node-PluginListTests.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Plugin-List-for-Node-PluginListTests.txt
@@ -2,6 +2,10 @@
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 
+import Nimble
+import NodesTesting
+import XCTest
+
 @MainActor
 final class ___VARIABLE_productName___PluginListTests: XCTestCase {
 

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-List-for-Node-PluginListTests.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Plugin-List-for-Node-PluginListTests.txt
@@ -2,6 +2,10 @@
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 
+import Nimble
+import NodesTesting
+import XCTest
+
 @MainActor
 final class ___VARIABLE_productName___PluginListTests: XCTestCase {
 


### PR DESCRIPTION
Explore branch: https://github.com/TinderApp/Nodes/compare/main...explore/add-plugin-list-test-template

- [x] Introduce PluginListTests.stencil
- [x] Add PluginListTests to StencilTemplate
- [x] Add isNimbleEnabled to PluginListStencilContext
- [x] Add pluginListTestsImports to stencil context
- [x] Add pluginListTests to permutation stencils
- [ ] **Inject pluginListTestsImports into permutation context** 
- [ ] Add PluginListTests to renderPluginList