### PR TITLE
Inject workerTestsImports into permutation context

### DIFF
--- a/Sources/NodesGenerator/XcodeTemplatePermutations/WorkerXcodeTemplatePermutation.swift
+++ b/Sources/NodesGenerator/XcodeTemplatePermutations/WorkerXcodeTemplatePermutation.swift
@@ -17,7 +17,7 @@ internal struct WorkerXcodeTemplatePermutation: XcodeTemplatePermutation {
             fileHeader: XcodeTemplateConstants.fileHeader,
             workerName: XcodeTemplateConstants.variable(XcodeTemplateConstants.productName),
             workerImports: worker.imports(with: config),
-            workerTestsImports: [],
+            workerTestsImports: workerTests.imports(with: config),
             workerGenericTypes: config.workerGenericTypes,
             isPeripheryCommentEnabled: config.isPeripheryCommentEnabled,
             isNimbleEnabled: config.isNimbleEnabled

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testWorkerXcodeTemplatePermutation.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testWorkerXcodeTemplatePermutation.1.txt
@@ -11,6 +11,7 @@
       - "<reactiveImport>"
       - "Nodes"
     - workerName: "___VARIABLE_productName___"
-    - workerTestsImports: 0 elements
+    ▿ workerTestsImports: 1 element
+      - "<baseTestImport>"
   ▿ stencils: 1 element
     - Worker

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testWorkerXcodeTemplate.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testWorkerXcodeTemplate.1.txt
@@ -14,7 +14,8 @@
           - "<reactiveImport>"
           - "Nodes"
         - workerName: "___VARIABLE_productName___"
-        - workerTestsImports: 0 elements
+        ▿ workerTestsImports: 1 element
+          - "<baseTestImport>"
       ▿ stencils: 1 element
         - Worker
   ▿ propertyList: XcodeTemplatePropertyList

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Worker-WorkerTests.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithIdentifier.Contents-Worker-WorkerTests.txt
@@ -2,6 +2,9 @@
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 
+import Nimble
+import XCTest
+
 final class ___VARIABLE_productName___WorkerTests: XCTestCase {
 
     private var worker: ___VARIABLE_productName___WorkerImp!

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Worker-WorkerTests.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatesTests/testGenerateWithURL.Contents-Worker-WorkerTests.txt
@@ -2,6 +2,9 @@
 
 #warning("Manually move this test file to the corresponding test target then delete this warning.")
 
+import Nimble
+import XCTest
+
 final class ___VARIABLE_productName___WorkerTests: XCTestCase {
 
     private var worker: ___VARIABLE_productName___WorkerImp!


### PR DESCRIPTION
Explore branch: https://github.com/TinderApp/Nodes/compare/main...explore/add-worker-tests-stencil

- [x] Introduce WorkerTests.stencil
- [x] Add WorkerTests to StencilTemplate
- [x] Add isNimbleEnabled to WorkerStencilContext
- [x] Add workerTestsImports to WorkerStencilContext
- [x] Add workerTests to permutation stencils
- [ ] **Inject workerTestsImports into permutation context**
- [ ] Add WorkerTests to renderWorker