### PR TITLE
Rename StencilTemplate.Variation.regular

### DIFF
--- a/Sources/NodesGenerator/StencilTemplate.swift
+++ b/Sources/NodesGenerator/StencilTemplate.swift
@@ -27,11 +27,11 @@ public enum StencilTemplate: CustomStringConvertible, Equatable, Sendable {
 
     public enum Variation: String, CaseIterable, Equatable, Sendable {
 
-        case `default` = ""
+        case regular = ""
         case swiftUI = "-SwiftUI"
 
         public static func variation(for kind: UIFramework.Kind) -> Self {
-            kind.isHostingSwiftUI ? .swiftUI : .default
+            kind.isHostingSwiftUI ? .swiftUI : .regular
         }
     }
 
@@ -112,7 +112,7 @@ public enum StencilTemplate: CustomStringConvertible, Equatable, Sendable {
         public init() {
             self.analytics = .analytics
             self.analyticsTests = .analyticsTests
-            self.builder = .builder(.default)
+            self.builder = .builder(.regular)
             self.builderTests = .builderTests
             self.context = .context
             self.contextTests = .contextTests

--- a/Tests/NodesGeneratorTests/StencilTemplateTests.swift
+++ b/Tests/NodesGeneratorTests/StencilTemplateTests.swift
@@ -11,7 +11,7 @@ final class StencilTemplateTests: XCTestCase, TestFactories {
     func testVariationRawValue() {
         StencilTemplate.Variation.allCases.forEach { variation in
             switch variation {
-            case .default:
+            case .regular:
                 expect(variation.rawValue).to(beEmpty())
             case .swiftUI:
                 expect(variation.rawValue) == "-SwiftUI"
@@ -24,7 +24,7 @@ final class StencilTemplateTests: XCTestCase, TestFactories {
             let variation: StencilTemplate.Variation = .variation(for: kind)
             switch kind {
             case .appKit, .uiKit, .custom:
-                expect(variation) == .default
+                expect(variation) == .regular
             case .uiKitSwiftUI:
                 expect(variation) == .swiftUI
             }
@@ -206,7 +206,7 @@ final class StencilTemplateTests: XCTestCase, TestFactories {
         let node: StencilTemplate.NodeViewInjected = .init()
         expect(node.stencils(includePlugin: true, includeTests: true)) == [
             .analytics,
-            .builder(.default),
+            .builder(.regular),
             .context,
             .flow,
             .state,
@@ -219,7 +219,7 @@ final class StencilTemplateTests: XCTestCase, TestFactories {
         ]
         expect(node.stencils(includePlugin: false, includeTests: true)) == [
             .analytics,
-            .builder(.default),
+            .builder(.regular),
             .context,
             .flow,
             .state,
@@ -230,7 +230,7 @@ final class StencilTemplateTests: XCTestCase, TestFactories {
         ]
         expect(node.stencils(includePlugin: true, includeTests: false)) == [
             .analytics,
-            .builder(.default),
+            .builder(.regular),
             .context,
             .flow,
             .state,
@@ -238,7 +238,7 @@ final class StencilTemplateTests: XCTestCase, TestFactories {
         ]
         expect(node.stencils(includePlugin: false, includeTests: false)) == [
             .analytics,
-            .builder(.default),
+            .builder(.regular),
             .context,
             .flow,
             .state
@@ -375,7 +375,7 @@ extension StencilTemplate {
     fileprivate static let allCases: [Self] = [
         .analytics,
         .analyticsTests,
-        .builder(.default),
+        .builder(.regular),
         .builder(.swiftUI),
         .builderTests,
         .context,
@@ -387,9 +387,9 @@ extension StencilTemplate {
         .pluginList,
         .pluginListTests,
         .state,
-        .viewController(.default),
+        .viewController(.regular),
         .viewController(.swiftUI),
-        .viewControllerTests(.default),
+        .viewControllerTests(.regular),
         .viewControllerTests(.swiftUI),
         .viewState,
         .viewStateFactoryTests,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilTemplateTests/testNode.Variation-regular.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilTemplateTests/testNode.Variation-regular.txt
@@ -2,7 +2,7 @@
   - analytics: Analytics
   - analyticsTests: AnalyticsTests
   ▿ builder: Builder
-    - builder: Variation.default
+    - builder: Variation.regular
   - builderTests: BuilderTests
   - context: Context
   - contextTests: ContextTests
@@ -12,8 +12,8 @@
   - pluginTests: PluginTests
   - state: State
   ▿ viewController: ViewController
-    - viewController: Variation.default
+    - viewController: Variation.regular
   ▿ viewControllerTests: ViewControllerTests
-    - viewControllerTests: Variation.default
+    - viewControllerTests: Variation.regular
   - viewState: ViewState
   - viewStateFactoryTests: ViewStateFactoryTests

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilTemplateTests/testNodeViewInjected.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilTemplateTests/testNodeViewInjected.1.txt
@@ -2,7 +2,7 @@
   - analytics: Analytics
   - analyticsTests: AnalyticsTests
   ▿ builder: Builder
-    - builder: Variation.default
+    - builder: Variation.regular
   - builderTests: BuilderTests
   - context: Context
   - contextTests: ContextTests

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeViewInjectedXcodeTemplatePermutation.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeViewInjectedXcodeTemplatePermutation.1.txt
@@ -74,7 +74,7 @@
   ▿ stencils: 11 elements
     - Analytics
     ▿ Builder
-      - builder: Variation.default
+      - builder: Variation.regular
     - Context
     - Flow
     - State

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.AppKit.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.AppKit.txt
@@ -104,12 +104,12 @@
   ▿ stencils: 15 elements
     - Analytics
     ▿ Builder
-      - builder: Variation.default
+      - builder: Variation.regular
     - Context
     - Flow
     - State
     ▿ ViewController
-      - viewController: Variation.default
+      - viewController: Variation.regular
     - ViewState
     - Plugin
     - AnalyticsTests
@@ -117,6 +117,6 @@
     - ContextTests
     - FlowTests
     ▿ ViewControllerTests
-      - viewControllerTests: Variation.default
+      - viewControllerTests: Variation.regular
     - ViewStateFactoryTests
     - PluginTests

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.AppKitCreatedForPluginList.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.AppKitCreatedForPluginList.txt
@@ -104,12 +104,12 @@
   ▿ stencils: 15 elements
     - Analytics
     ▿ Builder
-      - builder: Variation.default
+      - builder: Variation.regular
     - Context
     - Flow
     - State
     ▿ ViewController
-      - viewController: Variation.default
+      - viewController: Variation.regular
     - ViewState
     - Plugin
     - AnalyticsTests
@@ -117,6 +117,6 @@
     - ContextTests
     - FlowTests
     ▿ ViewControllerTests
-      - viewControllerTests: Variation.default
+      - viewControllerTests: Variation.regular
     - ViewStateFactoryTests
     - PluginTests

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.Custom.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.Custom.txt
@@ -104,12 +104,12 @@
   ▿ stencils: 15 elements
     - Analytics
     ▿ Builder
-      - builder: Variation.default
+      - builder: Variation.regular
     - Context
     - Flow
     - State
     ▿ ViewController
-      - viewController: Variation.default
+      - viewController: Variation.regular
     - ViewState
     - Plugin
     - AnalyticsTests
@@ -117,6 +117,6 @@
     - ContextTests
     - FlowTests
     ▿ ViewControllerTests
-      - viewControllerTests: Variation.default
+      - viewControllerTests: Variation.regular
     - ViewStateFactoryTests
     - PluginTests

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.CustomCreatedForPluginList.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.CustomCreatedForPluginList.txt
@@ -104,12 +104,12 @@
   ▿ stencils: 15 elements
     - Analytics
     ▿ Builder
-      - builder: Variation.default
+      - builder: Variation.regular
     - Context
     - Flow
     - State
     ▿ ViewController
-      - viewController: Variation.default
+      - viewController: Variation.regular
     - ViewState
     - Plugin
     - AnalyticsTests
@@ -117,6 +117,6 @@
     - ContextTests
     - FlowTests
     ▿ ViewControllerTests
-      - viewControllerTests: Variation.default
+      - viewControllerTests: Variation.regular
     - ViewStateFactoryTests
     - PluginTests

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.UIKit.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.UIKit.txt
@@ -104,12 +104,12 @@
   ▿ stencils: 15 elements
     - Analytics
     ▿ Builder
-      - builder: Variation.default
+      - builder: Variation.regular
     - Context
     - Flow
     - State
     ▿ ViewController
-      - viewController: Variation.default
+      - viewController: Variation.regular
     - ViewState
     - Plugin
     - AnalyticsTests
@@ -117,6 +117,6 @@
     - ContextTests
     - FlowTests
     ▿ ViewControllerTests
-      - viewControllerTests: Variation.default
+      - viewControllerTests: Variation.regular
     - ViewStateFactoryTests
     - PluginTests

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.UIKitCreatedForPluginList.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testNodeXcodeTemplatePermutation.UIKitCreatedForPluginList.txt
@@ -104,12 +104,12 @@
   ▿ stencils: 15 elements
     - Analytics
     ▿ Builder
-      - builder: Variation.default
+      - builder: Variation.regular
     - Context
     - Flow
     - State
     ▿ ViewController
-      - viewController: Variation.default
+      - viewController: Variation.regular
     - ViewState
     - Plugin
     - AnalyticsTests
@@ -117,6 +117,6 @@
     - ContextTests
     - FlowTests
     ▿ ViewControllerTests
-      - viewControllerTests: Variation.default
+      - viewControllerTests: Variation.regular
     - ViewStateFactoryTests
     - PluginTests

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testNodeViewInjectedXcodeTemplate.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testNodeViewInjectedXcodeTemplate.1.txt
@@ -77,7 +77,7 @@
       ▿ stencils: 11 elements
         - Analytics
         ▿ Builder
-          - builder: Variation.default
+          - builder: Variation.regular
         - Context
         - Flow
         - State

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testNodeXcodeTemplate.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testNodeXcodeTemplate.1.txt
@@ -107,12 +107,12 @@
       ▿ stencils: 15 elements
         - Analytics
         ▿ Builder
-          - builder: Variation.default
+          - builder: Variation.regular
         - Context
         - Flow
         - State
         ▿ ViewController
-          - viewController: Variation.default
+          - viewController: Variation.regular
         - ViewState
         - Plugin
         - AnalyticsTests
@@ -120,7 +120,7 @@
         - ContextTests
         - FlowTests
         ▿ ViewControllerTests
-          - viewControllerTests: Variation.default
+          - viewControllerTests: Variation.regular
         - ViewStateFactoryTests
         - PluginTests
     ▿ NodeXcodeTemplatePermutation
@@ -229,12 +229,12 @@
       ▿ stencils: 15 elements
         - Analytics
         ▿ Builder
-          - builder: Variation.default
+          - builder: Variation.regular
         - Context
         - Flow
         - State
         ▿ ViewController
-          - viewController: Variation.default
+          - viewController: Variation.regular
         - ViewState
         - Plugin
         - AnalyticsTests
@@ -242,7 +242,7 @@
         - ContextTests
         - FlowTests
         ▿ ViewControllerTests
-          - viewControllerTests: Variation.default
+          - viewControllerTests: Variation.regular
         - ViewStateFactoryTests
         - PluginTests
     ▿ NodeXcodeTemplatePermutation
@@ -351,12 +351,12 @@
       ▿ stencils: 15 elements
         - Analytics
         ▿ Builder
-          - builder: Variation.default
+          - builder: Variation.regular
         - Context
         - Flow
         - State
         ▿ ViewController
-          - viewController: Variation.default
+          - viewController: Variation.regular
         - ViewState
         - Plugin
         - AnalyticsTests
@@ -364,7 +364,7 @@
         - ContextTests
         - FlowTests
         ▿ ViewControllerTests
-          - viewControllerTests: Variation.default
+          - viewControllerTests: Variation.regular
         - ViewStateFactoryTests
         - PluginTests
     ▿ NodeXcodeTemplatePermutation
@@ -473,12 +473,12 @@
       ▿ stencils: 15 elements
         - Analytics
         ▿ Builder
-          - builder: Variation.default
+          - builder: Variation.regular
         - Context
         - Flow
         - State
         ▿ ViewController
-          - viewController: Variation.default
+          - viewController: Variation.regular
         - ViewState
         - Plugin
         - AnalyticsTests
@@ -486,7 +486,7 @@
         - ContextTests
         - FlowTests
         ▿ ViewControllerTests
-          - viewControllerTests: Variation.default
+          - viewControllerTests: Variation.regular
         - ViewStateFactoryTests
         - PluginTests
     ▿ NodeXcodeTemplatePermutation
@@ -839,12 +839,12 @@
       ▿ stencils: 15 elements
         - Analytics
         ▿ Builder
-          - builder: Variation.default
+          - builder: Variation.regular
         - Context
         - Flow
         - State
         ▿ ViewController
-          - viewController: Variation.default
+          - viewController: Variation.regular
         - ViewState
         - Plugin
         - AnalyticsTests
@@ -852,7 +852,7 @@
         - ContextTests
         - FlowTests
         ▿ ViewControllerTests
-          - viewControllerTests: Variation.default
+          - viewControllerTests: Variation.regular
         - ViewStateFactoryTests
         - PluginTests
     ▿ NodeXcodeTemplatePermutation
@@ -961,12 +961,12 @@
       ▿ stencils: 15 elements
         - Analytics
         ▿ Builder
-          - builder: Variation.default
+          - builder: Variation.regular
         - Context
         - Flow
         - State
         ▿ ViewController
-          - viewController: Variation.default
+          - viewController: Variation.regular
         - ViewState
         - Plugin
         - AnalyticsTests
@@ -974,7 +974,7 @@
         - ContextTests
         - FlowTests
         ▿ ViewControllerTests
-          - viewControllerTests: Variation.default
+          - viewControllerTests: Variation.regular
         - ViewStateFactoryTests
         - PluginTests
   ▿ propertyList: XcodeTemplatePropertyList


### PR DESCRIPTION
See #798.

- [x] Improve StencilTemplateTests testNode filename
- [x] Introduce UIFramework Kind isHostingSwiftUI
- [ ] **Rename StencilTemplate.Variation.regular**
- [ ] Introduce StencilTemplate Variation suffix
- [ ] Remove StencilTemplate Variation String rawValue
- [ ] Remove StencilTemplate.Node initializer external param