### PR TITLE
Remove StencilTemplate Variation String rawValue

### DIFF
--- a/Sources/NodesGenerator/StencilTemplate.swift
+++ b/Sources/NodesGenerator/StencilTemplate.swift
@@ -25,10 +25,10 @@ public enum StencilTemplate: CustomStringConvertible, Equatable, Sendable {
     case worker
     case workerTests
 
-    public enum Variation: String, CaseIterable, Equatable, Sendable {
+    public enum Variation: CaseIterable, Equatable, Sendable {
 
-        case regular = ""
-        case swiftUI = "-SwiftUI"
+        case regular
+        case swiftUI
 
         public var suffix: String {
             switch self {

--- a/Tests/NodesGeneratorTests/StencilTemplateTests.swift
+++ b/Tests/NodesGeneratorTests/StencilTemplateTests.swift
@@ -8,17 +8,6 @@ import XCTest
 
 final class StencilTemplateTests: XCTestCase, TestFactories {
 
-    func testVariationRawValue() {
-        StencilTemplate.Variation.allCases.forEach { variation in
-            switch variation {
-            case .regular:
-                expect(variation.rawValue).to(beEmpty())
-            case .swiftUI:
-                expect(variation.rawValue) == "-SwiftUI"
-            }
-        }
-    }
-
     func testVariationSuffix() {
         StencilTemplate.Variation.allCases.forEach { variation in
             switch variation {


### PR DESCRIPTION
See #798.

- [x] Improve StencilTemplateTests testNode filename
- [x] Introduce UIFramework Kind isHostingSwiftUI
- [x] Rename StencilTemplate.Variation.regular
- [x] Introduce StencilTemplate Variation suffix
- [ ] **Remove StencilTemplate Variation String rawValue**
- [ ] Remove StencilTemplate.Node initializer external param