### PR TITLE
Use triple slash comments rather than block based comments

### DIFF
--- a/Sources/NodesGenerator/Resources/Stencils/Analytics.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Analytics.stencil
@@ -7,28 +7,25 @@ import {{ import }}
 {% endif %}
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol {{ node_name }}Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 {% if analytics_properties %}
 internal final class {{ node_name }}AnalyticsImp {
 

--- a/Sources/NodesGenerator/Resources/Stencils/Builder-SwiftUI.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Builder-SwiftUI.stencil
@@ -6,10 +6,8 @@ import {{ import }}
 {% endfor %}
 {% endif %}
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 {% if plugin_list_name %}
@@ -18,10 +16,8 @@ internal protocol {{ node_name }}Flow: {{ plugin_list_name }}Flow {}
 internal protocol {{ node_name }}Flow: {{ view_controllable_flow_type }} {}
 {% endif %}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 {% if dependencies %}
@@ -34,56 +30,50 @@ public protocol {{ node_name }}Dependency: Dependency {
 public protocol {{ node_name }}Dependency: Dependency {}
 {% endif %}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias {{ node_name }}DynamicBuildDependency = {{ node_name }}Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias {{ node_name }}DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class {{ node_name }}Component: Component
 <
     {{ node_name }}Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
     {% if component_dependencies %}
 
@@ -114,15 +104,15 @@ public final class {{ node_name }}Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
@@ -131,10 +121,8 @@ public final class {{ node_name }}Component: Component
 {% if is_periphery_comment_enabled %}
 // periphery:ignore
 {% endif %}
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 {% if plugin_list_name %}
@@ -150,10 +138,8 @@ internal protocol {{ node_name }}Builder: AnyObject {
 {% if is_periphery_comment_enabled %}
 // periphery:ignore
 {% endif %}
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class {{ node_name }}BuilderImp: AbstractBuilder
 <
     {{ node_name }}Component,

--- a/Sources/NodesGenerator/Resources/Stencils/Builder.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Builder.stencil
@@ -6,10 +6,8 @@ import {{ import }}
 {% endfor %}
 {% endif %}
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 {% if owns_view %}
@@ -27,10 +25,8 @@ internal protocol {{ node_name }}Flow: Flow {}
 {% endif %}
 {% if node_name != "App" %}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 {% if dependencies %}
@@ -44,12 +40,10 @@ public protocol {{ node_name }}Dependency: Dependency {}
 {% endif %}
 {% endif %}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 {% if owns_view %}
 internal typealias {{ node_name }}DynamicBuildDependency = {{ node_name }}Listener
 {% elif node_name == "App" %}
@@ -58,20 +52,16 @@ internal typealias {{ node_name }}DynamicBuildDependency = Void
 internal typealias {{ node_name }}DynamicBuildDependency = ({{ node_name }}Listener, {{ node_name }}ViewControllable)
 {% endif %}
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias {{ node_name }}DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 {% if node_name == "App" %}
 public final class {{ node_name }}Component: BootstrapComponent {
 {% else %}
@@ -82,28 +72,28 @@ public final class {{ node_name }}Component: Component
 {% endif %}
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
     {% if component_dependencies %}
 
@@ -144,15 +134,15 @@ public final class {{ node_name }}Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
     {% if node_name == "App" %}
 
@@ -177,10 +167,8 @@ public final class {{ node_name }}Component: Component
 {% if is_periphery_comment_enabled %}
 // periphery:ignore
 {% endif %}
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 {% if plugin_list_name %}
@@ -205,10 +193,8 @@ internal protocol {{ node_name }}Builder: AnyObject {
 {% if is_periphery_comment_enabled %}
 // periphery:ignore
 {% endif %}
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class {{ node_name }}BuilderImp: AbstractBuilder
 <
     {{ node_name }}Component,

--- a/Sources/NodesGenerator/Resources/Stencils/Context.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Context.stencil
@@ -7,20 +7,16 @@ import {{ import }}
 {% endif %}
 {% if node_name != "App" %}
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol {{ node_name }}Listener: AnyObject {}
 {% endif %}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 {% if node_name == "App" %}
@@ -36,11 +32,9 @@ internal protocol {{ node_name }}FlowInterface: Flow {
 internal protocol {{ node_name }}FlowInterface: Flow {}
 {% endif %}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 {% if context_generic_types %}
 internal final class {{ node_name }}ContextImp: AbstractContext
 <

--- a/Sources/NodesGenerator/Resources/Stencils/Flow.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Flow.stencil
@@ -6,11 +6,9 @@ import {{ import }}
 {% endfor %}
 {% endif %}
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 {% if node_name == "App" %}
@@ -22,12 +20,10 @@ internal protocol {{ node_name }}ContextInterface: Context, RootListener {}
 {% else %}
 internal protocol {{ node_name }}ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 {% if not view_controllable_mock_contents %}
 /// @mockable
 {% endif %}
@@ -35,10 +31,8 @@ internal protocol {{ node_name }}ContextInterface: Context {}
 internal protocol {{ node_name }}ViewControllable: {{ view_controllable_type }} {}
 {% endif %}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class {{ node_name }}FlowImp: AbstractFlow
 <
     {{ node_name }}ContextInterface,

--- a/Sources/NodesGenerator/Resources/Stencils/Plugin.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Plugin.stencil
@@ -6,58 +6,54 @@ import {{ import }}
 {% endfor %}
 {% endif %}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol {{ plugin_name }}PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class {{ plugin_name }}PluginComponent: Component
 <
     {{ plugin_name }}PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> {{ plugin_name }}Component {
@@ -65,19 +61,15 @@ public final class {{ plugin_name }}PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias {{ plugin_name }}PluginStateType = Void
 
 {% if is_periphery_comment_enabled %}
 // periphery:ignore
 {% endif %}
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol {{ plugin_name }}Plugin {
@@ -87,10 +79,8 @@ internal protocol {{ plugin_name }}Plugin {
 {% if is_periphery_comment_enabled %}
 // periphery:ignore
 {% endif %}
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class {{ plugin_name }}PluginImp: Plugin
 <
     {{ plugin_name }}PluginComponent,

--- a/Sources/NodesGenerator/Resources/Stencils/PluginList.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/PluginList.stencil
@@ -9,10 +9,8 @@ import {{ import }}
 {% if is_periphery_comment_enabled %}
 // periphery:ignore
 {% endif %}
-/**
- PURPOSE:
- The common Flow interface.
- */
+/// PURPOSE:
+/// The common Flow interface.
 /// @mockable
 @MainActor
 internal protocol {{ plugin_list_name }}Flow: {{ view_controllable_flow_type }} {}
@@ -20,10 +18,8 @@ internal protocol {{ plugin_list_name }}Flow: {{ view_controllable_flow_type }} 
 {% if is_periphery_comment_enabled %}
 // periphery:ignore
 {% endif %}
-/**
- PURPOSE:
- The common Listener interface.
- */
+/// PURPOSE:
+/// The common Listener interface.
 /// @mockable
 @MainActor
 internal protocol {{ plugin_list_name }}Listener: AnyObject {}
@@ -31,10 +27,8 @@ internal protocol {{ plugin_list_name }}Listener: AnyObject {}
 {% if is_periphery_comment_enabled %}
 // periphery:ignore
 {% endif %}
-/**
- PURPOSE:
- The common Builder interface.
- */
+/// PURPOSE:
+/// The common Builder interface.
 /// @mockable
 @MainActor
 internal protocol {{ plugin_list_name }}Builder: AnyObject {
@@ -43,80 +37,70 @@ internal protocol {{ plugin_list_name }}Builder: AnyObject {
     ) -> {{ plugin_list_name }}Flow
 }
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
 /// @mockable
 @MainActor
 public protocol {{ plugin_list_name }}PluginListDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin List.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin List.
 public final class {{ plugin_list_name }}PluginListComponent: Component
 <
     {{ plugin_list_name }}PluginListDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
-         <Name>PluginComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
+     *      <Name>PluginComponent(parent: self)
+     *  }
+     *
      */
 }
 
-/**
- PURPOSE:
- The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
- */
+/// PURPOSE:
+/// The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
 internal typealias {{ plugin_list_name }}PluginListKeyType = String
 
-/**
- PURPOSE:
- To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
 internal typealias {{ plugin_list_name }}PluginListStateType = Void
 
 {% if is_periphery_comment_enabled %}
 // periphery:ignore
 {% endif %}
-/**
- PURPOSE:
- The Plugin List protocol (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin List protocol (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol {{ plugin_list_name }}PluginList {
@@ -128,10 +112,8 @@ internal protocol {{ plugin_list_name }}PluginList {
 {% if is_periphery_comment_enabled %}
 // periphery:ignore
 {% endif %}
-/**
- PURPOSE:
- Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
 internal final class {{ plugin_list_name }}PluginListImp: PluginList
 <
     {{ plugin_list_name }}PluginListKeyType,

--- a/Sources/NodesGenerator/Resources/Stencils/State.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/State.stencil
@@ -6,10 +6,8 @@ import {{ import }}
 {% endfor %}
 {% endif %}
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct {{ node_name }}State: Equatable {
 
 {% if node_name == "Root" %}

--- a/Sources/NodesGenerator/Resources/Stencils/ViewController-SwiftUI.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/ViewController-SwiftUI.stencil
@@ -6,19 +6,15 @@ import {{ import }}
 {% endfor %}
 {% endif %}
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol {{ node_name }}Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class {{ node_name }}ViewController: {{ view_controller_type }}
 <
     {{ node_name }}View
@@ -39,10 +35,8 @@ internal final class {{ node_name }}ViewController: {{ view_controller_type }}
 
 extension {{ node_name }}ViewController: {{ node_name }}ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct {{ node_name }}View {
 
     {% if is_periphery_comment_enabled %}
@@ -84,10 +78,8 @@ extension {{ node_name }}View: View {
 {% if is_periphery_comment_enabled %}
 // periphery:ignore
 {% endif %}
-/**
- PURPOSE:
- The SwiftUI preview (excluded from release builds).
- */
+/// PURPOSE:
+/// The SwiftUI preview (excluded from release builds).
 internal struct {{ node_name }}View_Previews: PreviewProvider {
 
     internal static var previews: some View {

--- a/Sources/NodesGenerator/Resources/Stencils/ViewController.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/ViewController.stencil
@@ -6,11 +6,9 @@ import {{ import }}
 {% endfor %}
 {% endif %}
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 {% if node_name == "Root" %}
@@ -21,10 +19,8 @@ internal protocol {{ node_name }}Receiver: AnyObject {
 internal protocol {{ node_name }}Receiver: AnyObject {}
 {% endif %}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class {{ node_name }}ViewController: {{ view_controller_type }}, StateObserver {
     {% if view_controller_static_content %}
 

--- a/Sources/NodesGenerator/Resources/Stencils/ViewState.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/ViewState.stencil
@@ -6,10 +6,8 @@ import {{ import }}
 {% endfor %}
 {% endif %}
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 {% if node_name == "Root" %}
 internal struct {{ node_name }}ViewState: Equatable {
 
@@ -19,10 +17,8 @@ internal struct {{ node_name }}ViewState: Equatable {
 internal struct {{ node_name }}ViewState: Equatable {}
 {% endif %}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class {{ node_name }}ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Sources/NodesGenerator/Resources/Stencils/Worker.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Worker.stencil
@@ -9,20 +9,16 @@ import {{ import }}
 {% if is_periphery_comment_enabled %}
 // periphery:ignore
 {% endif %}
-/**
- PURPOSE:
- Encapsulates work to be performed by the Node.
- */
+/// PURPOSE:
+/// Encapsulates work to be performed by the Node.
 /// @mockable
 internal protocol {{ worker_name }}Worker: Worker {}
 
 {% if is_periphery_comment_enabled %}
 // periphery:ignore
 {% endif %}
-/**
- PURPOSE:
- Concrete implementation of the Worker.
- */
+/// PURPOSE:
+/// Concrete implementation of the Worker.
 {% if worker_generic_types %}
 internal final class {{ worker_name }}WorkerImp: AbstractWorker
 <

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateAppPreset.Contents-AppAnalytics-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateAppPreset.Contents-AppAnalytics-swift.txt
@@ -3,28 +3,25 @@
 //
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol AppAnalytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class AppAnalyticsImp {}
 
 extension AppAnalyticsImp: AppAnalytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateAppPreset.Contents-AppBuilder-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateAppPreset.Contents-AppBuilder-swift.txt
@@ -6,61 +6,53 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol AppFlow: Flow {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias AppDynamicBuildDependency = Void
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias AppDynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class AppComponent: BootstrapComponent {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     fileprivate let appService: AppService = AppServiceImp()
@@ -80,15 +72,15 @@ public final class AppComponent: BootstrapComponent {
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func windowSceneComponentFactory() -> WindowSceneComponent {
@@ -98,20 +90,16 @@ public final class AppComponent: BootstrapComponent {
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol AppBuilder: AnyObject {
     func build() -> AppFlow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class AppBuilderImp: AbstractBuilder
 <
     AppComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateAppPreset.Contents-AppContext-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateAppPreset.Contents-AppContext-swift.txt
@@ -5,11 +5,9 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol AppFlowInterface: Flow {
@@ -17,11 +15,9 @@ internal protocol AppFlowInterface: Flow {
     func detachWindowScene(_ viewController: WindowSceneViewControllable)
 }
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class AppContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateAppPreset.Contents-AppFlow-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateAppPreset.Contents-AppFlow-swift.txt
@@ -4,19 +4,15 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol AppContextInterface: Context, WindowSceneListener {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class AppFlowImp: AbstractFlow
 <
     AppContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateAppPreset.Contents-AppState-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateAppPreset.Contents-AppState-swift.txt
@@ -2,10 +2,8 @@
 //  Created by <author> on <date>.
 //
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct AppState: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateRootPreset.Contents-RootAnalytics-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateRootPreset.Contents-RootAnalytics-swift.txt
@@ -3,28 +3,25 @@
 //
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol RootAnalytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class RootAnalyticsImp {}
 
 extension RootAnalyticsImp: RootAnalytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateRootPreset.Contents-RootBuilder-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateRootPreset.Contents-RootBuilder-swift.txt
@@ -6,72 +6,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol RootFlow: ViewControllableFlow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol RootDependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias RootDynamicBuildDependency = RootListener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias RootDynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class RootComponent: Component
 <
     RootDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: RootDynamicComponentDependency
@@ -92,24 +82,22 @@ public final class RootComponent: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol RootBuilder: AnyObject {
@@ -118,10 +106,8 @@ internal protocol RootBuilder: AnyObject {
     ) -> RootFlow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class RootBuilderImp: AbstractBuilder
 <
     RootComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateRootPreset.Contents-RootContext-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateRootPreset.Contents-RootContext-swift.txt
@@ -5,30 +5,24 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol RootListener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol RootFlowInterface: Flow {
     func didBecomeReady()
 }
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class RootContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateRootPreset.Contents-RootFlow-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateRootPreset.Contents-RootFlow-swift.txt
@@ -4,29 +4,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol RootContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol RootViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class RootFlowImp: AbstractFlow
 <
     RootContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateRootPreset.Contents-RootState-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateRootPreset.Contents-RootState-swift.txt
@@ -2,10 +2,8 @@
 //  Created by <author> on <date>.
 //
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct RootState: Equatable {
 
     internal var name: String

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateRootPreset.Contents-RootViewController-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateRootPreset.Contents-RootViewController-swift.txt
@@ -6,21 +6,17 @@ import Combine
 import Nodes
 import UIKit
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol RootReceiver: AnyObject {
     func viewDidAppear()
 }
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class RootViewController: UIViewController, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateRootPreset.Contents-RootViewState-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateRootPreset.Contents-RootViewState-swift.txt
@@ -4,19 +4,15 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct RootViewState: Equatable {
 
     internal let title: String
 }
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class RootViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateScenePreset.Contents-WindowSceneAnalytics-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateScenePreset.Contents-WindowSceneAnalytics-swift.txt
@@ -3,28 +3,25 @@
 //
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol WindowSceneAnalytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class WindowSceneAnalyticsImp {}
 
 extension WindowSceneAnalyticsImp: WindowSceneAnalytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateScenePreset.Contents-WindowSceneBuilder-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateScenePreset.Contents-WindowSceneBuilder-swift.txt
@@ -6,74 +6,64 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol WindowSceneFlow: Flow {
     func getViewController() -> WindowSceneViewControllable
 }
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol WindowSceneDependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias WindowSceneDynamicBuildDependency = (WindowSceneListener, WindowSceneViewControllable)
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias WindowSceneDynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class WindowSceneComponent: Component
 <
     WindowSceneDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: WindowSceneDynamicComponentDependency
@@ -94,15 +84,15 @@ public final class WindowSceneComponent: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func windowComponentFactory() -> WindowComponent {
@@ -112,10 +102,8 @@ public final class WindowSceneComponent: Component
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol WindowSceneBuilder: AnyObject {
@@ -125,10 +113,8 @@ internal protocol WindowSceneBuilder: AnyObject {
     ) -> WindowSceneFlow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class WindowSceneBuilderImp: AbstractBuilder
 <
     WindowSceneComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateScenePreset.Contents-WindowSceneContext-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateScenePreset.Contents-WindowSceneContext-swift.txt
@@ -5,28 +5,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol WindowSceneListener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol WindowSceneFlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class WindowSceneContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateScenePreset.Contents-WindowSceneFlow-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateScenePreset.Contents-WindowSceneFlow-swift.txt
@@ -4,19 +4,15 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol WindowSceneContextInterface: Context, WindowListener {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class WindowSceneFlowImp: AbstractFlow
 <
     WindowSceneContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateScenePreset.Contents-WindowSceneState-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateScenePreset.Contents-WindowSceneState-swift.txt
@@ -2,10 +2,8 @@
 //  Created by <author> on <date>.
 //
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct WindowSceneState: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateWindowPreset.Contents-WindowAnalytics-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateWindowPreset.Contents-WindowAnalytics-swift.txt
@@ -3,28 +3,25 @@
 //
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol WindowAnalytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class WindowAnalyticsImp {}
 
 extension WindowAnalyticsImp: WindowAnalytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateWindowPreset.Contents-WindowBuilder-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateWindowPreset.Contents-WindowBuilder-swift.txt
@@ -6,72 +6,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol WindowFlow: Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol WindowDependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias WindowDynamicBuildDependency = (WindowListener, WindowViewControllable)
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias WindowDynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class WindowComponent: Component
 <
     WindowDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: WindowDynamicComponentDependency
@@ -92,15 +82,15 @@ public final class WindowComponent: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func rootComponentFactory() -> RootComponent {
@@ -110,10 +100,8 @@ public final class WindowComponent: Component
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol WindowBuilder: AnyObject {
@@ -123,10 +111,8 @@ internal protocol WindowBuilder: AnyObject {
     ) -> WindowFlow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class WindowBuilderImp: AbstractBuilder
 <
     WindowComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateWindowPreset.Contents-WindowContext-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateWindowPreset.Contents-WindowContext-swift.txt
@@ -5,28 +5,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol WindowListener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol WindowFlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class WindowContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateWindowPreset.Contents-WindowFlow-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateWindowPreset.Contents-WindowFlow-swift.txt
@@ -4,19 +4,15 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol WindowContextInterface: Context, RootListener {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class WindowFlowImp: AbstractFlow
 <
     WindowContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateWindowPreset.Contents-WindowState-swift.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/PresetGeneratorTests/testGenerateWindowPreset.Contents-WindowState-swift.txt
@@ -2,10 +2,8 @@
 //  Created by <author> on <date>.
 //
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct WindowState: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKit-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKit-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKit-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKitSwiftUI-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKitSwiftUI-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-AppKitSwiftUI-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-Custom-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-Custom-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-Custom-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKit-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKit-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKit-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKitSwiftUI-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKitSwiftUI-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Analytics-UIKitSwiftUI-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKit-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKitSwiftUI-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKitSwiftUI-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-AppKitSwiftUI-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-Custom-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKit-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKitSwiftUI-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKitSwiftUI-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Builder-UIKitSwiftUI-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKitSwiftUI-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKitSwiftUI-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-AppKitSwiftUI-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-Custom-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKitSwiftUI-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKitSwiftUI-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Context-UIKitSwiftUI-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKit-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKitSwiftUI-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKitSwiftUI-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-AppKitSwiftUI-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-Custom-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-Custom-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-Custom-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKit-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKitSwiftUI-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKitSwiftUI-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.Flow-UIKitSwiftUI-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKit-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKit-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKit-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKitSwiftUI-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKitSwiftUI-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-AppKitSwiftUI-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-Custom-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-Custom-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-Custom-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKit-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKit-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKit-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKitSwiftUI-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKitSwiftUI-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.State-UIKitSwiftUI-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKit-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKit-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKit-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKitSwiftUI-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -20,10 +16,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKitSwiftUI-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -27,10 +23,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     // periphery:ignore
@@ -63,10 +57,8 @@ extension <nodeName>View: View {
 // MARK: - Preview
 
 // periphery:ignore
-/**
- PURPOSE:
- The SwiftUI preview (excluded from release builds).
- */
+/// PURPOSE:
+/// The SwiftUI preview (excluded from release builds).
 internal struct <nodeName>View_Previews: PreviewProvider {
 
     internal static var previews: some View {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-AppKitSwiftUI-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -28,10 +24,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     // periphery:ignore
@@ -64,10 +58,8 @@ extension <nodeName>View: View {
 // MARK: - Preview
 
 // periphery:ignore
-/**
- PURPOSE:
- The SwiftUI preview (excluded from release builds).
- */
+/// PURPOSE:
+/// The SwiftUI preview (excluded from release builds).
 internal struct <nodeName>View_Previews: PreviewProvider {
 
     internal static var previews: some View {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-Custom-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-Custom-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-Custom-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKit-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKit-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKit-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKitSwiftUI-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -20,10 +16,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKitSwiftUI-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -27,10 +23,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     // periphery:ignore
@@ -63,10 +57,8 @@ extension <nodeName>View: View {
 // MARK: - Preview
 
 // periphery:ignore
-/**
- PURPOSE:
- The SwiftUI preview (excluded from release builds).
- */
+/// PURPOSE:
+/// The SwiftUI preview (excluded from release builds).
 internal struct <nodeName>View_Previews: PreviewProvider {
 
     internal static var previews: some View {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewController-UIKitSwiftUI-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -28,10 +24,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     // periphery:ignore
@@ -64,10 +58,8 @@ extension <nodeName>View: View {
 // MARK: - Preview
 
 // periphery:ignore
-/**
- PURPOSE:
- The SwiftUI preview (excluded from release builds).
- */
+/// PURPOSE:
+/// The SwiftUI preview (excluded from release builds).
 internal struct <nodeName>View_Previews: PreviewProvider {
 
     internal static var previews: some View {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKit-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKit-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKit-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKitSwiftUI-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKitSwiftUI-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-AppKitSwiftUI-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-Custom-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-Custom-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-Custom-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKit-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKit-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKit-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKitSwiftUI-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKitSwiftUI-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode.ViewState-UIKitSwiftUI-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Analytics-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Analytics-UIKit-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol AppAnalytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class AppAnalyticsImp {}
 
 extension AppAnalyticsImp: AppAnalytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Analytics-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Analytics-UIKit-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol AppAnalytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class AppAnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Analytics-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Analytics-UIKit-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol AppAnalytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class AppAnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Builder-UIKit-mockCount-0.txt
@@ -1,60 +1,52 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol AppFlow: Flow {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias AppDynamicBuildDependency = Void
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias AppDynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class AppComponent: BootstrapComponent {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     fileprivate let appService: AppService = AppServiceImp()
@@ -74,15 +66,15 @@ public final class AppComponent: BootstrapComponent {
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func windowSceneComponentFactory() -> WindowSceneComponent {
@@ -92,20 +84,16 @@ public final class AppComponent: BootstrapComponent {
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol AppBuilder: AnyObject {
     func build() -> AppFlow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class AppBuilderImp: AbstractBuilder
 <
     AppComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Builder-UIKit-mockCount-1.txt
@@ -2,61 +2,53 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol AppFlow: Flow {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias AppDynamicBuildDependency = Void
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias AppDynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class AppComponent: BootstrapComponent {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     fileprivate let appService: AppService = AppServiceImp()
@@ -78,15 +70,15 @@ public final class AppComponent: BootstrapComponent {
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func windowSceneComponentFactory() -> WindowSceneComponent {
@@ -97,10 +89,8 @@ public final class AppComponent: BootstrapComponent {
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol AppBuilder: AnyObject {
@@ -108,10 +98,8 @@ internal protocol AppBuilder: AnyObject {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class AppBuilderImp: AbstractBuilder
 <
     AppComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Builder-UIKit-mockCount-2.txt
@@ -3,61 +3,53 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol AppFlow: Flow {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias AppDynamicBuildDependency = Void
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias AppDynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class AppComponent: BootstrapComponent {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     fileprivate let appService: AppService = AppServiceImp()
@@ -79,15 +71,15 @@ public final class AppComponent: BootstrapComponent {
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func windowSceneComponentFactory() -> WindowSceneComponent {
@@ -98,10 +90,8 @@ public final class AppComponent: BootstrapComponent {
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol AppBuilder: AnyObject {
@@ -109,10 +99,8 @@ internal protocol AppBuilder: AnyObject {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class AppBuilderImp: AbstractBuilder
 <
     AppComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-0.txt
@@ -1,10 +1,8 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol AppFlowInterface: Flow {
@@ -12,11 +10,9 @@ internal protocol AppFlowInterface: Flow {
     func detachWindowScene(_ viewController: WindowSceneViewControllable)
 }
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class AppContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-1.txt
@@ -2,11 +2,9 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol AppFlowInterface: Flow {
@@ -14,11 +12,9 @@ internal protocol AppFlowInterface: Flow {
     func detachWindowScene(_ viewController: WindowSceneViewControllable)
 }
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class AppContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Context-UIKit-mockCount-2.txt
@@ -3,11 +3,9 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol AppFlowInterface: Flow {
@@ -15,11 +13,9 @@ internal protocol AppFlowInterface: Flow {
     func detachWindowScene(_ viewController: WindowSceneViewControllable)
 }
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class AppContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Flow-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Flow-UIKit-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol AppContextInterface: Context, WindowSceneListener {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class AppFlowImp: AbstractFlow
 <
     AppContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Flow-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Flow-UIKit-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol AppContextInterface: Context, WindowSceneListener {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class AppFlowImp: AbstractFlow
 <
     AppContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Flow-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.Flow-UIKit-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol AppContextInterface: Context, WindowSceneListener {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class AppFlowImp: AbstractFlow
 <
     AppContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct AppState: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct AppState: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetApp.State-UIKit-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct AppState: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Analytics-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Analytics-UIKit-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol RootAnalytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class RootAnalyticsImp {}
 
 extension RootAnalyticsImp: RootAnalytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Analytics-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Analytics-UIKit-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol RootAnalytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class RootAnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Analytics-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Analytics-UIKit-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol RootAnalytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class RootAnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Builder-UIKit-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol RootFlow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol RootDependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias RootDynamicBuildDependency = RootListener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias RootDynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class RootComponent: Component
 <
     RootDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: RootDynamicComponentDependency
@@ -86,24 +76,22 @@ public final class RootComponent: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol RootBuilder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol RootBuilder: AnyObject {
     ) -> RootFlow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class RootBuilderImp: AbstractBuilder
 <
     RootComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Builder-UIKit-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol RootFlow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol RootDependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias RootDynamicBuildDependency = RootListener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias RootDynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class RootComponent: Component
 <
     RootDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class RootComponent: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol RootBuilder: AnyObject {
@@ -120,10 +108,8 @@ internal protocol RootBuilder: AnyObject {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class RootBuilderImp: AbstractBuilder
 <
     RootComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Builder-UIKit-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol RootFlow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol RootDependency: Dependency {
@@ -22,56 +18,50 @@ public protocol RootDependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias RootDynamicBuildDependency = RootListener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias RootDynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class RootComponent: Component
 <
     RootDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class RootComponent: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol RootBuilder: AnyObject {
@@ -122,10 +110,8 @@ internal protocol RootBuilder: AnyObject {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class RootBuilderImp: AbstractBuilder
 <
     RootComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Context-UIKit-mockCount-0.txt
@@ -1,29 +1,23 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol RootListener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol RootFlowInterface: Flow {
     func didBecomeReady()
 }
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class RootContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Context-UIKit-mockCount-1.txt
@@ -2,30 +2,24 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol RootListener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol RootFlowInterface: Flow {
     func didBecomeReady()
 }
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class RootContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Context-UIKit-mockCount-2.txt
@@ -3,30 +3,24 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol RootListener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol RootFlowInterface: Flow {
     func didBecomeReady()
 }
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class RootContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Flow-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Flow-UIKit-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol RootContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol RootViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class RootFlowImp: AbstractFlow
 <
     RootContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Flow-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Flow-UIKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol RootContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol RootViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class RootFlowImp: AbstractFlow
 <
     RootContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Flow-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.Flow-UIKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol RootContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol RootViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class RootFlowImp: AbstractFlow
 <
     RootContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.State-UIKit-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct RootState: Equatable {
 
     internal var name: String

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.State-UIKit-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct RootState: Equatable {
 
     internal var name: String

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.State-UIKit-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct RootState: Equatable {
 
     internal var name: String

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewController-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewController-UIKit-mockCount-0.txt
@@ -1,20 +1,16 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol RootReceiver: AnyObject {
     func viewDidAppear()
 }
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class RootViewController: <viewControllerType>, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewController-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewController-UIKit-mockCount-1.txt
@@ -2,21 +2,17 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol RootReceiver: AnyObject {
     func viewDidAppear()
 }
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class RootViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewController-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewController-UIKit-mockCount-2.txt
@@ -3,21 +3,17 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol RootReceiver: AnyObject {
     func viewDidAppear()
 }
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class RootViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewState-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewState-UIKit-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct RootViewState: Equatable {
 
     internal let title: String
 }
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class RootViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewState-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewState-UIKit-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct RootViewState: Equatable {
 
     internal let title: String
 }
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class RootViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewState-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetRoot.ViewState-UIKit-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct RootViewState: Equatable {
 
     internal let title: String
 }
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class RootViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Analytics-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Analytics-UIKit-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol WindowSceneAnalytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class WindowSceneAnalyticsImp {}
 
 extension WindowSceneAnalyticsImp: WindowSceneAnalytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Analytics-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Analytics-UIKit-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol WindowSceneAnalytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class WindowSceneAnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Analytics-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Analytics-UIKit-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol WindowSceneAnalytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class WindowSceneAnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Builder-UIKit-mockCount-0.txt
@@ -1,73 +1,63 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol WindowSceneFlow: Flow {
     func getViewController() -> WindowSceneViewControllable
 }
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol WindowSceneDependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias WindowSceneDynamicBuildDependency = (WindowSceneListener, WindowSceneViewControllable)
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias WindowSceneDynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class WindowSceneComponent: Component
 <
     WindowSceneDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: WindowSceneDynamicComponentDependency
@@ -88,15 +78,15 @@ public final class WindowSceneComponent: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func windowComponentFactory() -> WindowComponent {
@@ -106,10 +96,8 @@ public final class WindowSceneComponent: Component
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol WindowSceneBuilder: AnyObject {
@@ -119,10 +107,8 @@ internal protocol WindowSceneBuilder: AnyObject {
     ) -> WindowSceneFlow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class WindowSceneBuilderImp: AbstractBuilder
 <
     WindowSceneComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Builder-UIKit-mockCount-1.txt
@@ -2,76 +2,66 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol WindowSceneFlow: Flow {
     func getViewController() -> WindowSceneViewControllable
 }
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol WindowSceneDependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias WindowSceneDynamicBuildDependency = (WindowSceneListener, WindowSceneViewControllable)
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias WindowSceneDynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class WindowSceneComponent: Component
 <
     WindowSceneDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,15 +84,15 @@ public final class WindowSceneComponent: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func windowComponentFactory() -> WindowComponent {
@@ -113,10 +103,8 @@ public final class WindowSceneComponent: Component
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol WindowSceneBuilder: AnyObject {
@@ -127,10 +115,8 @@ internal protocol WindowSceneBuilder: AnyObject {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class WindowSceneBuilderImp: AbstractBuilder
 <
     WindowSceneComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Builder-UIKit-mockCount-2.txt
@@ -3,20 +3,16 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol WindowSceneFlow: Flow {
     func getViewController() -> WindowSceneViewControllable
 }
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol WindowSceneDependency: Dependency {
@@ -24,56 +20,50 @@ public protocol WindowSceneDependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias WindowSceneDynamicBuildDependency = (WindowSceneListener, WindowSceneViewControllable)
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias WindowSceneDynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class WindowSceneComponent: Component
 <
     WindowSceneDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -96,15 +86,15 @@ public final class WindowSceneComponent: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func windowComponentFactory() -> WindowComponent {
@@ -115,10 +105,8 @@ public final class WindowSceneComponent: Component
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol WindowSceneBuilder: AnyObject {
@@ -129,10 +117,8 @@ internal protocol WindowSceneBuilder: AnyObject {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class WindowSceneBuilderImp: AbstractBuilder
 <
     WindowSceneComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol WindowSceneListener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol WindowSceneFlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class WindowSceneContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol WindowSceneListener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol WindowSceneFlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class WindowSceneContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Context-UIKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol WindowSceneListener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol WindowSceneFlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class WindowSceneContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Flow-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Flow-UIKit-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol WindowSceneContextInterface: Context, WindowListener {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class WindowSceneFlowImp: AbstractFlow
 <
     WindowSceneContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Flow-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Flow-UIKit-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol WindowSceneContextInterface: Context, WindowListener {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class WindowSceneFlowImp: AbstractFlow
 <
     WindowSceneContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Flow-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.Flow-UIKit-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol WindowSceneContextInterface: Context, WindowListener {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class WindowSceneFlowImp: AbstractFlow
 <
     WindowSceneContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct WindowSceneState: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct WindowSceneState: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetScene.State-UIKit-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct WindowSceneState: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Analytics-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Analytics-UIKit-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol WindowAnalytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class WindowAnalyticsImp {}
 
 extension WindowAnalyticsImp: WindowAnalytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Analytics-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Analytics-UIKit-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol WindowAnalytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class WindowAnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Analytics-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Analytics-UIKit-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol WindowAnalytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class WindowAnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Builder-UIKit-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol WindowFlow: Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol WindowDependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias WindowDynamicBuildDependency = (WindowListener, WindowViewControllable)
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias WindowDynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class WindowComponent: Component
 <
     WindowDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: WindowDynamicComponentDependency
@@ -86,15 +76,15 @@ public final class WindowComponent: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func rootComponentFactory() -> RootComponent {
@@ -104,10 +94,8 @@ public final class WindowComponent: Component
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol WindowBuilder: AnyObject {
@@ -117,10 +105,8 @@ internal protocol WindowBuilder: AnyObject {
     ) -> WindowFlow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class WindowBuilderImp: AbstractBuilder
 <
     WindowComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Builder-UIKit-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol WindowFlow: Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol WindowDependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias WindowDynamicBuildDependency = (WindowListener, WindowViewControllable)
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias WindowDynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class WindowComponent: Component
 <
     WindowDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,15 +82,15 @@ public final class WindowComponent: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func rootComponentFactory() -> RootComponent {
@@ -111,10 +101,8 @@ public final class WindowComponent: Component
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol WindowBuilder: AnyObject {
@@ -125,10 +113,8 @@ internal protocol WindowBuilder: AnyObject {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class WindowBuilderImp: AbstractBuilder
 <
     WindowComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Builder-UIKit-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol WindowFlow: Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol WindowDependency: Dependency {
@@ -22,56 +18,50 @@ public protocol WindowDependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias WindowDynamicBuildDependency = (WindowListener, WindowViewControllable)
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias WindowDynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class WindowComponent: Component
 <
     WindowDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,15 +84,15 @@ public final class WindowComponent: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func rootComponentFactory() -> RootComponent {
@@ -113,10 +103,8 @@ public final class WindowComponent: Component
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol WindowBuilder: AnyObject {
@@ -127,10 +115,8 @@ internal protocol WindowBuilder: AnyObject {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class WindowBuilderImp: AbstractBuilder
 <
     WindowComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol WindowListener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol WindowFlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class WindowContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol WindowListener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol WindowFlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class WindowContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Context-UIKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol WindowListener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol WindowFlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class WindowContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Flow-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Flow-UIKit-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol WindowContextInterface: Context, RootListener {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class WindowFlowImp: AbstractFlow
 <
     WindowContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Flow-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Flow-UIKit-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol WindowContextInterface: Context, RootListener {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class WindowFlowImp: AbstractFlow
 <
     WindowContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Flow-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.Flow-UIKit-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol WindowContextInterface: Context, RootListener {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class WindowFlowImp: AbstractFlow
 <
     WindowContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct WindowState: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct WindowState: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodePresetWindow.State-UIKit-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct WindowState: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Analytics-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Analytics-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Analytics-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Analytics-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Analytics-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Analytics-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = (<nodeName>Listener, <nodeName>ViewControllable)
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -113,10 +101,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = (<nodeName>Listener, <nodeName>ViewControllable)
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -121,10 +109,8 @@ internal protocol <nodeName>Builder: AnyObject {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Builder-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = (<nodeName>Listener, <nodeName>ViewControllable)
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -123,10 +111,8 @@ internal protocol <nodeName>Builder: AnyObject {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Context-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Flow-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Flow-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Flow-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Flow-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Flow-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.Flow-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.State-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.State-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.State-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.State-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.State-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNodeViewInjected.State-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKit-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKit-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKit-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKitSwiftUI-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKitSwiftUI-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-AppKitSwiftUI-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-Custom-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-Custom-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-Custom-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKit-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKit-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKit-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKitSwiftUI-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKitSwiftUI-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Analytics-UIKitSwiftUI-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKit-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKit-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKit-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKitSwiftUI-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKitSwiftUI-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-AppKitSwiftUI-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-Custom-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-Custom-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-Custom-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKit-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKit-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKit-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKitSwiftUI-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKitSwiftUI-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Builder-UIKitSwiftUI-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKit-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKitSwiftUI-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKitSwiftUI-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-AppKitSwiftUI-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-Custom-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-Custom-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-Custom-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKit-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKitSwiftUI-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKitSwiftUI-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Context-UIKitSwiftUI-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKit-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKitSwiftUI-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKitSwiftUI-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-AppKitSwiftUI-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-Custom-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-Custom-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-Custom-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKit-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKitSwiftUI-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKitSwiftUI-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Flow-UIKitSwiftUI-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKit-mockCount-0.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,26 +55,20 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
     func create() -> Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKit-mockCount-1.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKit-mockCount-2.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKitSwiftUI-mockCount-0.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,26 +55,20 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
     func create() -> Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKitSwiftUI-mockCount-1.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-AppKitSwiftUI-mockCount-2.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-Custom-mockCount-0.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,26 +55,20 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
     func create() -> Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-Custom-mockCount-1.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-Custom-mockCount-2.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKit-mockCount-0.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,26 +55,20 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
     func create() -> Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKit-mockCount-1.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKit-mockCount-2.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKitSwiftUI-mockCount-0.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,26 +55,20 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
     func create() -> Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKitSwiftUI-mockCount-1.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.Plugin-UIKitSwiftUI-mockCount-2.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKit-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKit-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKit-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKitSwiftUI-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKitSwiftUI-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-AppKitSwiftUI-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-Custom-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-Custom-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-Custom-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKit-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKit-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKit-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKitSwiftUI-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKitSwiftUI-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.State-UIKitSwiftUI-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKit-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKit-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKit-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKitSwiftUI-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -20,10 +16,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKitSwiftUI-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -27,10 +23,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     // periphery:ignore
@@ -63,10 +57,8 @@ extension <nodeName>View: View {
 // MARK: - Preview
 
 // periphery:ignore
-/**
- PURPOSE:
- The SwiftUI preview (excluded from release builds).
- */
+/// PURPOSE:
+/// The SwiftUI preview (excluded from release builds).
 internal struct <nodeName>View_Previews: PreviewProvider {
 
     internal static var previews: some View {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-AppKitSwiftUI-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -28,10 +24,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     // periphery:ignore
@@ -64,10 +58,8 @@ extension <nodeName>View: View {
 // MARK: - Preview
 
 // periphery:ignore
-/**
- PURPOSE:
- The SwiftUI preview (excluded from release builds).
- */
+/// PURPOSE:
+/// The SwiftUI preview (excluded from release builds).
 internal struct <nodeName>View_Previews: PreviewProvider {
 
     internal static var previews: some View {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-Custom-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-Custom-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-Custom-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKit-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKit-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKit-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKitSwiftUI-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -20,10 +16,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKitSwiftUI-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -27,10 +23,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     // periphery:ignore
@@ -63,10 +57,8 @@ extension <nodeName>View: View {
 // MARK: - Preview
 
 // periphery:ignore
-/**
- PURPOSE:
- The SwiftUI preview (excluded from release builds).
- */
+/// PURPOSE:
+/// The SwiftUI preview (excluded from release builds).
 internal struct <nodeName>View_Previews: PreviewProvider {
 
     internal static var previews: some View {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewController-UIKitSwiftUI-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -28,10 +24,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     // periphery:ignore
@@ -64,10 +58,8 @@ extension <nodeName>View: View {
 // MARK: - Preview
 
 // periphery:ignore
-/**
- PURPOSE:
- The SwiftUI preview (excluded from release builds).
- */
+/// PURPOSE:
+/// The SwiftUI preview (excluded from release builds).
 internal struct <nodeName>View_Previews: PreviewProvider {
 
     internal static var previews: some View {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKit-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKit-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKit-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKitSwiftUI-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKitSwiftUI-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-AppKitSwiftUI-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-Custom-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-Custom-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-Custom-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKit-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKit-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKit-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKitSwiftUI-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKitSwiftUI-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPlugin.ViewState-UIKitSwiftUI-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKit-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKit-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKit-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKitSwiftUI-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKitSwiftUI-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-AppKitSwiftUI-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-Custom-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-Custom-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-Custom-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKit-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKit-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKit-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKitSwiftUI-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKitSwiftUI-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Analytics-UIKitSwiftUI-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKit-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKit-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKit-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKitSwiftUI-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKitSwiftUI-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-AppKitSwiftUI-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-Custom-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-Custom-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-Custom-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKit-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKit-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKit-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKitSwiftUI-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKitSwiftUI-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Builder-UIKitSwiftUI-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKit-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKitSwiftUI-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKitSwiftUI-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-AppKitSwiftUI-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-Custom-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-Custom-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-Custom-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKit-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKitSwiftUI-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKitSwiftUI-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Context-UIKitSwiftUI-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKit-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKitSwiftUI-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKitSwiftUI-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-AppKitSwiftUI-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-Custom-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-Custom-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-Custom-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKit-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKitSwiftUI-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKitSwiftUI-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Flow-UIKitSwiftUI-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKit-mockCount-0.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,26 +55,20 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
     func create() -> Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKit-mockCount-1.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKit-mockCount-2.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKitSwiftUI-mockCount-0.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,26 +55,20 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
     func create() -> Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKitSwiftUI-mockCount-1.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-AppKitSwiftUI-mockCount-2.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-Custom-mockCount-0.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,26 +55,20 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
     func create() -> Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-Custom-mockCount-1.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-Custom-mockCount-2.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKit-mockCount-0.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,26 +55,20 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
     func create() -> Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKit-mockCount-1.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKit-mockCount-2.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKitSwiftUI-mockCount-0.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,26 +55,20 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
     func create() -> Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKitSwiftUI-mockCount-1.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.Plugin-UIKitSwiftUI-mockCount-2.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class PluginComponent: Component
 <
     PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> Component {
@@ -59,17 +55,13 @@ public final class PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol Plugin {
@@ -77,10 +69,8 @@ internal protocol Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class PluginImp: Plugin
 <
     PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKit-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKit-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKit-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKitSwiftUI-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKitSwiftUI-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-AppKitSwiftUI-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-Custom-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-Custom-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-Custom-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKit-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKit-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKit-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKitSwiftUI-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKitSwiftUI-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.State-UIKitSwiftUI-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKit-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKit-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKit-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKitSwiftUI-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -20,10 +16,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKitSwiftUI-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -27,10 +23,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     // periphery:ignore
@@ -63,10 +57,8 @@ extension <nodeName>View: View {
 // MARK: - Preview
 
 // periphery:ignore
-/**
- PURPOSE:
- The SwiftUI preview (excluded from release builds).
- */
+/// PURPOSE:
+/// The SwiftUI preview (excluded from release builds).
 internal struct <nodeName>View_Previews: PreviewProvider {
 
     internal static var previews: some View {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-AppKitSwiftUI-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -28,10 +24,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     // periphery:ignore
@@ -64,10 +58,8 @@ extension <nodeName>View: View {
 // MARK: - Preview
 
 // periphery:ignore
-/**
- PURPOSE:
- The SwiftUI preview (excluded from release builds).
- */
+/// PURPOSE:
+/// The SwiftUI preview (excluded from release builds).
 internal struct <nodeName>View_Previews: PreviewProvider {
 
     internal static var previews: some View {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-Custom-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-Custom-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-Custom-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKit-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKit-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKit-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKitSwiftUI-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -20,10 +16,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKitSwiftUI-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -27,10 +23,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     // periphery:ignore
@@ -63,10 +57,8 @@ extension <nodeName>View: View {
 // MARK: - Preview
 
 // periphery:ignore
-/**
- PURPOSE:
- The SwiftUI preview (excluded from release builds).
- */
+/// PURPOSE:
+/// The SwiftUI preview (excluded from release builds).
 internal struct <nodeName>View_Previews: PreviewProvider {
 
     internal static var previews: some View {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewController-UIKitSwiftUI-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -28,10 +24,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     // periphery:ignore
@@ -64,10 +58,8 @@ extension <nodeName>View: View {
 // MARK: - Preview
 
 // periphery:ignore
-/**
- PURPOSE:
- The SwiftUI preview (excluded from release builds).
- */
+/// PURPOSE:
+/// The SwiftUI preview (excluded from release builds).
 internal struct <nodeName>View_Previews: PreviewProvider {
 
     internal static var previews: some View {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKit-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKit-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKit-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKitSwiftUI-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKitSwiftUI-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-AppKitSwiftUI-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-Custom-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-Custom-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-Custom-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKit-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKit-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKit-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKitSwiftUI-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKitSwiftUI-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withPluginAndTests.ViewState-UIKitSwiftUI-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKit-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKit-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKit-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKitSwiftUI-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKitSwiftUI-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-AppKitSwiftUI-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-Custom-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-Custom-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-Custom-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKit-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKit-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKit-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKitSwiftUI-mockCount-0.txt
@@ -1,28 +1,25 @@
 //<fileHeader>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {}
 
 extension <nodeName>AnalyticsImp: <nodeName>Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKitSwiftUI-mockCount-1.txt
@@ -3,28 +3,25 @@
 import <analyticsImport>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName>: <analyticsPropertyType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Analytics-UIKitSwiftUI-mockCount-2.txt
@@ -4,28 +4,25 @@ import <analyticsImport1>
 import <analyticsImport2>
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol <nodeName>Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class <nodeName>AnalyticsImp {
 
     private let <analyticsPropertyName1>: <analyticsPropertyType1>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKit-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKit-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKit-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKitSwiftUI-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKitSwiftUI-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-AppKitSwiftUI-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-Custom-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-Custom-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-Custom-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKit-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKit-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKit-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKitSwiftUI-mockCount-0.txt
@@ -1,71 +1,61 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: <nodeName>DynamicComponentDependency
@@ -86,24 +76,22 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: AnyObject {
@@ -112,10 +100,8 @@ internal protocol <nodeName>Builder: AnyObject {
     ) -> <nodeName>Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKitSwiftUI-mockCount-1.txt
@@ -2,74 +2,64 @@
 
 import <builderImport>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
     var <dependencyName>: <dependencyType> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -92,25 +82,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -120,10 +108,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Builder-UIKitSwiftUI-mockCount-2.txt
@@ -3,18 +3,14 @@
 import <builderImport1>
 import <builderImport2>
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Flow: <pluginListName>Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol <nodeName>Dependency: Dependency {
@@ -22,56 +18,50 @@ public protocol <nodeName>Dependency: Dependency {
     var <dependencyName2>: <dependencyType2> { get }
 }
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicBuildDependency = <nodeName>Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias <nodeName>DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class <nodeName>Component: Component
 <
     <nodeName>Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     // periphery:ignore
@@ -94,25 +84,23 @@ public final class <nodeName>Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
 // periphery:ignore
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <nodeName>Builder: <pluginListName>Builder {
@@ -122,10 +110,8 @@ internal protocol <nodeName>Builder: <pluginListName>Builder {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class <nodeName>BuilderImp: AbstractBuilder
 <
     <nodeName>Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKit-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKitSwiftUI-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKitSwiftUI-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-AppKitSwiftUI-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-Custom-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-Custom-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-Custom-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKit-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKitSwiftUI-mockCount-0.txt
@@ -1,27 +1,21 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext {
 
     /// The Flow instance.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKitSwiftUI-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <contextImport>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Context-UIKitSwiftUI-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <contextImport1>
 import <contextImport2>
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class <nodeName>ContextImp: AbstractContext
 <
     <contextGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKit-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKitSwiftUI-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKitSwiftUI-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-AppKitSwiftUI-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-Custom-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-Custom-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-Custom-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKit-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKit-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKit-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKitSwiftUI-mockCount-0.txt
@@ -1,28 +1,22 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKitSwiftUI-mockCount-1.txt
@@ -2,28 +2,22 @@
 
 import <flowImport>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.Flow-UIKitSwiftUI-mockCount-2.txt
@@ -3,28 +3,22 @@
 import <flowImport1>
 import <flowImport2>
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol <nodeName>ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 @MainActor
 internal protocol <nodeName>ViewControllable: <viewControllableType> {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class <nodeName>FlowImp: AbstractFlow
 <
     <nodeName>ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKit-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKit-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKit-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKitSwiftUI-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKitSwiftUI-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-AppKitSwiftUI-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-Custom-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-Custom-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-Custom-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKit-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKit-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKit-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKitSwiftUI-mockCount-0.txt
@@ -1,9 +1,7 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKitSwiftUI-mockCount-1.txt
@@ -2,10 +2,8 @@
 
 import <stateImport>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.State-UIKitSwiftUI-mockCount-2.txt
@@ -3,10 +3,8 @@
 import <stateImport1>
 import <stateImport2>
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct <nodeName>State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKit-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKit-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKit-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKitSwiftUI-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -20,10 +16,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKitSwiftUI-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -27,10 +23,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     // periphery:ignore
@@ -63,10 +57,8 @@ extension <nodeName>View: View {
 // MARK: - Preview
 
 // periphery:ignore
-/**
- PURPOSE:
- The SwiftUI preview (excluded from release builds).
- */
+/// PURPOSE:
+/// The SwiftUI preview (excluded from release builds).
 internal struct <nodeName>View_Previews: PreviewProvider {
 
     internal static var previews: some View {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-AppKitSwiftUI-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -28,10 +24,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     // periphery:ignore
@@ -64,10 +58,8 @@ extension <nodeName>View: View {
 // MARK: - Preview
 
 // periphery:ignore
-/**
- PURPOSE:
- The SwiftUI preview (excluded from release builds).
- */
+/// PURPOSE:
+/// The SwiftUI preview (excluded from release builds).
 internal struct <nodeName>View_Previews: PreviewProvider {
 
     internal static var previews: some View {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-Custom-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-Custom-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-Custom-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKit-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKit-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKit-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class <nodeName>ViewController: <viewControllerType>, StateObserver {
 
     <viewControllerStaticContent>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKitSwiftUI-mockCount-0.txt
@@ -1,18 +1,14 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -20,10 +16,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKitSwiftUI-mockCount-1.txt
@@ -2,19 +2,15 @@
 
 import <viewControllerImport>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -27,10 +23,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     // periphery:ignore
@@ -63,10 +57,8 @@ extension <nodeName>View: View {
 // MARK: - Preview
 
 // periphery:ignore
-/**
- PURPOSE:
- The SwiftUI preview (excluded from release builds).
- */
+/// PURPOSE:
+/// The SwiftUI preview (excluded from release builds).
 internal struct <nodeName>View_Previews: PreviewProvider {
 
     internal static var previews: some View {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewController-UIKitSwiftUI-mockCount-2.txt
@@ -3,19 +3,15 @@
 import <viewControllerImport1>
 import <viewControllerImport2>
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol <nodeName>Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class <nodeName>ViewController: <viewControllerType>
 <
     <nodeName>View
@@ -28,10 +24,8 @@ internal final class <nodeName>ViewController: <viewControllerType>
 
 extension <nodeName>ViewController: <nodeName>ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct <nodeName>View {
 
     // periphery:ignore
@@ -64,10 +58,8 @@ extension <nodeName>View: View {
 // MARK: - Preview
 
 // periphery:ignore
-/**
- PURPOSE:
- The SwiftUI preview (excluded from release builds).
- */
+/// PURPOSE:
+/// The SwiftUI preview (excluded from release builds).
 internal struct <nodeName>View_Previews: PreviewProvider {
 
     internal static var previews: some View {

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKit-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKit-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKit-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKitSwiftUI-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKitSwiftUI-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-AppKitSwiftUI-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-Custom-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-Custom-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-Custom-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-Custom-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-Custom-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-Custom-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKit-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKit-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKit-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKit-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKit-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKit-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKitSwiftUI-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKitSwiftUI-mockCount-0.txt
@@ -1,15 +1,11 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKitSwiftUI-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKitSwiftUI-mockCount-1.txt
@@ -2,16 +2,12 @@
 
 import <viewStateImport>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKitSwiftUI-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderNode_withTests.ViewState-UIKitSwiftUI-mockCount-2.txt
@@ -3,16 +3,12 @@
 import <viewStateImport1>
 import <viewStateImport2>
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct <nodeName>ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class <nodeName>ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.Plugin-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.Plugin-mockCount-0.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol <pluginName>PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class <pluginName>PluginComponent: Component
 <
     <pluginName>PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> <pluginName>Component {
@@ -59,26 +55,20 @@ public final class <pluginName>PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias <pluginName>PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <pluginName>Plugin {
     func create() -> <pluginName>Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class <pluginName>PluginImp: Plugin
 <
     <pluginName>PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.Plugin-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.Plugin-mockCount-1.txt
@@ -2,58 +2,54 @@
 
 import <pluginImport>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol <pluginName>PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class <pluginName>PluginComponent: Component
 <
     <pluginName>PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> <pluginName>Component {
@@ -61,17 +57,13 @@ public final class <pluginName>PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias <pluginName>PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <pluginName>Plugin {
@@ -79,10 +71,8 @@ internal protocol <pluginName>Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class <pluginName>PluginImp: Plugin
 <
     <pluginName>PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.Plugin-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin.Plugin-mockCount-2.txt
@@ -3,58 +3,54 @@
 import <pluginImport1>
 import <pluginImport2>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol <pluginName>PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class <pluginName>PluginComponent: Component
 <
     <pluginName>PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> <pluginName>Component {
@@ -62,17 +58,13 @@ public final class <pluginName>PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias <pluginName>PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <pluginName>Plugin {
@@ -80,10 +72,8 @@ internal protocol <pluginName>Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class <pluginName>PluginImp: Plugin
 <
     <pluginName>PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginList-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginList-mockCount-0.txt
@@ -1,25 +1,19 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The common Flow interface.
- */
+/// PURPOSE:
+/// The common Flow interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- The common Listener interface.
- */
+/// PURPOSE:
+/// The common Listener interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The common Builder interface.
- */
+/// PURPOSE:
+/// The common Builder interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Builder: AnyObject {
@@ -28,77 +22,67 @@ internal protocol <pluginListName>Builder: AnyObject {
     ) -> <pluginListName>Flow
 }
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
 /// @mockable
 @MainActor
 public protocol <pluginListName>PluginListDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin List.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin List.
 public final class <pluginListName>PluginListComponent: Component
 <
     <pluginListName>PluginListDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
-         <Name>PluginComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
+     *      <Name>PluginComponent(parent: self)
+     *  }
+     *
      */
 }
 
-/**
- PURPOSE:
- The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
- */
+/// PURPOSE:
+/// The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
 internal typealias <pluginListName>PluginListKeyType = String
 
-/**
- PURPOSE:
- To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
 internal typealias <pluginListName>PluginListStateType = Void
 
-/**
- PURPOSE:
- The Plugin List protocol (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin List protocol (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <pluginListName>PluginList {
@@ -107,10 +91,8 @@ internal protocol <pluginListName>PluginList {
     func create(key: <pluginListName>PluginListKeyType) -> <pluginListName>Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
 internal final class <pluginListName>PluginListImp: PluginList
 <
     <pluginListName>PluginListKeyType,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginList-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginList-mockCount-1.txt
@@ -3,28 +3,22 @@
 import <pluginListImport>
 
 // periphery:ignore
-/**
- PURPOSE:
- The common Flow interface.
- */
+/// PURPOSE:
+/// The common Flow interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
 
 // periphery:ignore
-/**
- PURPOSE:
- The common Listener interface.
- */
+/// PURPOSE:
+/// The common Listener interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Listener: AnyObject {}
 
 // periphery:ignore
-/**
- PURPOSE:
- The common Builder interface.
- */
+/// PURPOSE:
+/// The common Builder interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Builder: AnyObject {
@@ -33,78 +27,68 @@ internal protocol <pluginListName>Builder: AnyObject {
     ) -> <pluginListName>Flow
 }
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
 /// @mockable
 @MainActor
 public protocol <pluginListName>PluginListDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin List.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin List.
 public final class <pluginListName>PluginListComponent: Component
 <
     <pluginListName>PluginListDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
-         <Name>PluginComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
+     *      <Name>PluginComponent(parent: self)
+     *  }
+     *
      */
 }
 
-/**
- PURPOSE:
- The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
- */
+/// PURPOSE:
+/// The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
 internal typealias <pluginListName>PluginListKeyType = String
 
-/**
- PURPOSE:
- To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
 internal typealias <pluginListName>PluginListStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin List protocol (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin List protocol (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <pluginListName>PluginList {
@@ -114,10 +98,8 @@ internal protocol <pluginListName>PluginList {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
 internal final class <pluginListName>PluginListImp: PluginList
 <
     <pluginListName>PluginListKeyType,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginList-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginList-mockCount-2.txt
@@ -4,28 +4,22 @@ import <pluginListImport1>
 import <pluginListImport2>
 
 // periphery:ignore
-/**
- PURPOSE:
- The common Flow interface.
- */
+/// PURPOSE:
+/// The common Flow interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
 
 // periphery:ignore
-/**
- PURPOSE:
- The common Listener interface.
- */
+/// PURPOSE:
+/// The common Listener interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Listener: AnyObject {}
 
 // periphery:ignore
-/**
- PURPOSE:
- The common Builder interface.
- */
+/// PURPOSE:
+/// The common Builder interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Builder: AnyObject {
@@ -34,78 +28,68 @@ internal protocol <pluginListName>Builder: AnyObject {
     ) -> <pluginListName>Flow
 }
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
 /// @mockable
 @MainActor
 public protocol <pluginListName>PluginListDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin List.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin List.
 public final class <pluginListName>PluginListComponent: Component
 <
     <pluginListName>PluginListDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
-         <Name>PluginComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
+     *      <Name>PluginComponent(parent: self)
+     *  }
+     *
      */
 }
 
-/**
- PURPOSE:
- The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
- */
+/// PURPOSE:
+/// The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
 internal typealias <pluginListName>PluginListKeyType = String
 
-/**
- PURPOSE:
- To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
 internal typealias <pluginListName>PluginListStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin List protocol (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin List protocol (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <pluginListName>PluginList {
@@ -115,10 +99,8 @@ internal protocol <pluginListName>PluginList {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
 internal final class <pluginListName>PluginListImp: PluginList
 <
     <pluginListName>PluginListKeyType,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginList-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginList-mockCount-0.txt
@@ -1,25 +1,19 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- The common Flow interface.
- */
+/// PURPOSE:
+/// The common Flow interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
 
-/**
- PURPOSE:
- The common Listener interface.
- */
+/// PURPOSE:
+/// The common Listener interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Listener: AnyObject {}
 
-/**
- PURPOSE:
- The common Builder interface.
- */
+/// PURPOSE:
+/// The common Builder interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Builder: AnyObject {
@@ -28,77 +22,67 @@ internal protocol <pluginListName>Builder: AnyObject {
     ) -> <pluginListName>Flow
 }
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
 /// @mockable
 @MainActor
 public protocol <pluginListName>PluginListDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin List.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin List.
 public final class <pluginListName>PluginListComponent: Component
 <
     <pluginListName>PluginListDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
-         <Name>PluginComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
+     *      <Name>PluginComponent(parent: self)
+     *  }
+     *
      */
 }
 
-/**
- PURPOSE:
- The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
- */
+/// PURPOSE:
+/// The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
 internal typealias <pluginListName>PluginListKeyType = String
 
-/**
- PURPOSE:
- To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
 internal typealias <pluginListName>PluginListStateType = Void
 
-/**
- PURPOSE:
- The Plugin List protocol (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin List protocol (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <pluginListName>PluginList {
@@ -107,10 +91,8 @@ internal protocol <pluginListName>PluginList {
     func create(key: <pluginListName>PluginListKeyType) -> <pluginListName>Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
 internal final class <pluginListName>PluginListImp: PluginList
 <
     <pluginListName>PluginListKeyType,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginList-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginList-mockCount-1.txt
@@ -3,28 +3,22 @@
 import <pluginListImport>
 
 // periphery:ignore
-/**
- PURPOSE:
- The common Flow interface.
- */
+/// PURPOSE:
+/// The common Flow interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
 
 // periphery:ignore
-/**
- PURPOSE:
- The common Listener interface.
- */
+/// PURPOSE:
+/// The common Listener interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Listener: AnyObject {}
 
 // periphery:ignore
-/**
- PURPOSE:
- The common Builder interface.
- */
+/// PURPOSE:
+/// The common Builder interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Builder: AnyObject {
@@ -33,78 +27,68 @@ internal protocol <pluginListName>Builder: AnyObject {
     ) -> <pluginListName>Flow
 }
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
 /// @mockable
 @MainActor
 public protocol <pluginListName>PluginListDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin List.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin List.
 public final class <pluginListName>PluginListComponent: Component
 <
     <pluginListName>PluginListDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
-         <Name>PluginComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
+     *      <Name>PluginComponent(parent: self)
+     *  }
+     *
      */
 }
 
-/**
- PURPOSE:
- The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
- */
+/// PURPOSE:
+/// The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
 internal typealias <pluginListName>PluginListKeyType = String
 
-/**
- PURPOSE:
- To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
 internal typealias <pluginListName>PluginListStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin List protocol (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin List protocol (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <pluginListName>PluginList {
@@ -114,10 +98,8 @@ internal protocol <pluginListName>PluginList {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
 internal final class <pluginListName>PluginListImp: PluginList
 <
     <pluginListName>PluginListKeyType,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginList-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginList-mockCount-2.txt
@@ -4,28 +4,22 @@ import <pluginListImport1>
 import <pluginListImport2>
 
 // periphery:ignore
-/**
- PURPOSE:
- The common Flow interface.
- */
+/// PURPOSE:
+/// The common Flow interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
 
 // periphery:ignore
-/**
- PURPOSE:
- The common Listener interface.
- */
+/// PURPOSE:
+/// The common Listener interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Listener: AnyObject {}
 
 // periphery:ignore
-/**
- PURPOSE:
- The common Builder interface.
- */
+/// PURPOSE:
+/// The common Builder interface.
 /// @mockable
 @MainActor
 internal protocol <pluginListName>Builder: AnyObject {
@@ -34,78 +28,68 @@ internal protocol <pluginListName>Builder: AnyObject {
     ) -> <pluginListName>Flow
 }
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
 /// @mockable
 @MainActor
 public protocol <pluginListName>PluginListDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin List.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin List.
 public final class <pluginListName>PluginListComponent: Component
 <
     <pluginListName>PluginListDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
-         <Name>PluginComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
+     *      <Name>PluginComponent(parent: self)
+     *  }
+     *
      */
 }
 
-/**
- PURPOSE:
- The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
- */
+/// PURPOSE:
+/// The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
 internal typealias <pluginListName>PluginListKeyType = String
 
-/**
- PURPOSE:
- To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
 internal typealias <pluginListName>PluginListStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin List protocol (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin List protocol (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <pluginListName>PluginList {
@@ -115,10 +99,8 @@ internal protocol <pluginListName>PluginList {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
 internal final class <pluginListName>PluginListImp: PluginList
 <
     <pluginListName>PluginListKeyType,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin_withTests.Plugin-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin_withTests.Plugin-mockCount-0.txt
@@ -1,57 +1,53 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol <pluginName>PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class <pluginName>PluginComponent: Component
 <
     <pluginName>PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> <pluginName>Component {
@@ -59,26 +55,20 @@ public final class <pluginName>PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias <pluginName>PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <pluginName>Plugin {
     func create() -> <pluginName>Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class <pluginName>PluginImp: Plugin
 <
     <pluginName>PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin_withTests.Plugin-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin_withTests.Plugin-mockCount-1.txt
@@ -2,58 +2,54 @@
 
 import <pluginImport>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol <pluginName>PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class <pluginName>PluginComponent: Component
 <
     <pluginName>PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> <pluginName>Component {
@@ -61,17 +57,13 @@ public final class <pluginName>PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias <pluginName>PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <pluginName>Plugin {
@@ -79,10 +71,8 @@ internal protocol <pluginName>Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class <pluginName>PluginImp: Plugin
 <
     <pluginName>PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin_withTests.Plugin-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPlugin_withTests.Plugin-mockCount-2.txt
@@ -3,58 +3,54 @@
 import <pluginImport1>
 import <pluginImport2>
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol <pluginName>PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class <pluginName>PluginComponent: Component
 <
     <pluginName>PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> <pluginName>Component {
@@ -62,17 +58,13 @@ public final class <pluginName>PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias <pluginName>PluginStateType = Void
 
 // periphery:ignore
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol <pluginName>Plugin {
@@ -80,10 +72,8 @@ internal protocol <pluginName>Plugin {
 }
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class <pluginName>PluginImp: Plugin
 <
     <pluginName>PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker.Worker-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker.Worker-mockCount-0.txt
@@ -1,16 +1,12 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Encapsulates work to be performed by the Node.
- */
+/// PURPOSE:
+/// Encapsulates work to be performed by the Node.
 /// @mockable
 internal protocol <workerName>Worker: Worker {}
 
-/**
- PURPOSE:
- Concrete implementation of the Worker.
- */
+/// PURPOSE:
+/// Concrete implementation of the Worker.
 internal final class <workerName>WorkerImp: AbstractWorker {
 
     /// The initializer.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker.Worker-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker.Worker-mockCount-1.txt
@@ -3,18 +3,14 @@
 import <workerImport>
 
 // periphery:ignore
-/**
- PURPOSE:
- Encapsulates work to be performed by the Node.
- */
+/// PURPOSE:
+/// Encapsulates work to be performed by the Node.
 /// @mockable
 internal protocol <workerName>Worker: Worker {}
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Worker.
- */
+/// PURPOSE:
+/// Concrete implementation of the Worker.
 internal final class <workerName>WorkerImp: AbstractWorker
 <
     <workerGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker.Worker-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker.Worker-mockCount-2.txt
@@ -4,18 +4,14 @@ import <workerImport1>
 import <workerImport2>
 
 // periphery:ignore
-/**
- PURPOSE:
- Encapsulates work to be performed by the Node.
- */
+/// PURPOSE:
+/// Encapsulates work to be performed by the Node.
 /// @mockable
 internal protocol <workerName>Worker: Worker {}
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Worker.
- */
+/// PURPOSE:
+/// Concrete implementation of the Worker.
 internal final class <workerName>WorkerImp: AbstractWorker
 <
     <workerGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker_withTests.Worker-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker_withTests.Worker-mockCount-0.txt
@@ -1,16 +1,12 @@
 //<fileHeader>
 
-/**
- PURPOSE:
- Encapsulates work to be performed by the Node.
- */
+/// PURPOSE:
+/// Encapsulates work to be performed by the Node.
 /// @mockable
 internal protocol <workerName>Worker: Worker {}
 
-/**
- PURPOSE:
- Concrete implementation of the Worker.
- */
+/// PURPOSE:
+/// Concrete implementation of the Worker.
 internal final class <workerName>WorkerImp: AbstractWorker {
 
     /// The initializer.

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker_withTests.Worker-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker_withTests.Worker-mockCount-1.txt
@@ -3,18 +3,14 @@
 import <workerImport>
 
 // periphery:ignore
-/**
- PURPOSE:
- Encapsulates work to be performed by the Node.
- */
+/// PURPOSE:
+/// Encapsulates work to be performed by the Node.
 /// @mockable
 internal protocol <workerName>Worker: Worker {}
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Worker.
- */
+/// PURPOSE:
+/// Concrete implementation of the Worker.
 internal final class <workerName>WorkerImp: AbstractWorker
 <
     <workerGenericType>

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker_withTests.Worker-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderWorker_withTests.Worker-mockCount-2.txt
@@ -4,18 +4,14 @@ import <workerImport1>
 import <workerImport2>
 
 // periphery:ignore
-/**
- PURPOSE:
- Encapsulates work to be performed by the Node.
- */
+/// PURPOSE:
+/// Encapsulates work to be performed by the Node.
 /// @mockable
 internal protocol <workerName>Worker: Worker {}
 
 // periphery:ignore
-/**
- PURPOSE:
- Concrete implementation of the Worker.
- */
+/// PURPOSE:
+/// Concrete implementation of the Worker.
 internal final class <workerName>WorkerImp: AbstractWorker
 <
     <workerGenericType1>,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKit-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKit-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKit-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKit-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ViewControllableFlow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: AnyObject {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: AnyObject {
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKit-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKit-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKit-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKit-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKit-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKit-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKit-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKit-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKit-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKit-ViewController.txt
@@ -4,19 +4,15 @@ import AppKit
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class ___VARIABLE_productName___ViewController: NSViewController, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKit-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKit-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitCreatedForPluginList-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitCreatedForPluginList-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitCreatedForPluginList-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitCreatedForPluginList-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ___VARIABLE_PluginListName___Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName___Builder {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName_
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitCreatedForPluginList-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitCreatedForPluginList-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitCreatedForPluginList-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitCreatedForPluginList-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitCreatedForPluginList-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitCreatedForPluginList-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitCreatedForPluginList-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitCreatedForPluginList-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitCreatedForPluginList-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitCreatedForPluginList-ViewController.txt
@@ -4,19 +4,15 @@ import AppKit
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class ___VARIABLE_productName___ViewController: NSViewController, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitCreatedForPluginList-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitCreatedForPluginList-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUI-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUI-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUI-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUI-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ViewControllableFlow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: AnyObject {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: AnyObject {
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUI-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUI-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUI-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUI-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUI-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUI-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUI-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUI-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUI-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUI-ViewController.txt
@@ -4,19 +4,15 @@ import Combine
 import Nodes
 import SwiftUI
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class ___VARIABLE_productName___ViewController: NSHostingController
 <
     ___VARIABLE_productName___View
@@ -24,10 +20,8 @@ internal final class ___VARIABLE_productName___ViewController: NSHostingControll
 
 extension ___VARIABLE_productName___ViewController: ___VARIABLE_productName___ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct ___VARIABLE_productName___View {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUI-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUI-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUICreatedForPluginList-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUICreatedForPluginList-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUICreatedForPluginList-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUICreatedForPluginList-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ___VARIABLE_PluginListName___Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName___Builder {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName_
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUICreatedForPluginList-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUICreatedForPluginList-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUICreatedForPluginList-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUICreatedForPluginList-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUICreatedForPluginList-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUICreatedForPluginList-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUICreatedForPluginList-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUICreatedForPluginList-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUICreatedForPluginList-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUICreatedForPluginList-ViewController.txt
@@ -4,19 +4,15 @@ import Combine
 import Nodes
 import SwiftUI
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class ___VARIABLE_productName___ViewController: NSHostingController
 <
     ___VARIABLE_productName___View
@@ -24,10 +20,8 @@ internal final class ___VARIABLE_productName___ViewController: NSHostingControll
 
 extension ___VARIABLE_productName___ViewController: ___VARIABLE_productName___ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct ___VARIABLE_productName___View {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUICreatedForPluginList-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-AppKitSwiftUICreatedForPluginList-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Custom-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Custom-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Custom-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Custom-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ViewControllableFlow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: AnyObject {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: AnyObject {
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Custom-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Custom-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Custom-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Custom-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Custom-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Custom-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Custom-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Custom-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Custom-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Custom-ViewController.txt
@@ -4,19 +4,15 @@ import Combine
 import CustomFramework
 import Nodes
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class ___VARIABLE_productName___ViewController: CustomViewController, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Custom-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Custom-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-CustomCreatedForPluginList-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-CustomCreatedForPluginList-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-CustomCreatedForPluginList-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-CustomCreatedForPluginList-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ___VARIABLE_PluginListName___Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName___Builder {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName_
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-CustomCreatedForPluginList-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-CustomCreatedForPluginList-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-CustomCreatedForPluginList-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-CustomCreatedForPluginList-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-CustomCreatedForPluginList-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-CustomCreatedForPluginList-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-CustomCreatedForPluginList-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-CustomCreatedForPluginList-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-CustomCreatedForPluginList-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-CustomCreatedForPluginList-ViewController.txt
@@ -4,19 +4,15 @@ import Combine
 import CustomFramework
 import Nodes
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class ___VARIABLE_productName___ViewController: CustomViewController, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-CustomCreatedForPluginList-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-CustomCreatedForPluginList-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Plugin-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Plugin-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-PluginList-PluginList.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-PluginList-PluginList.txt
@@ -3,26 +3,20 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The common Flow interface.
- */
+/// PURPOSE:
+/// The common Flow interface.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ViewControllableFlow {}
 
-/**
- PURPOSE:
- The common Listener interface.
- */
+/// PURPOSE:
+/// The common Listener interface.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The common Builder interface.
- */
+/// PURPOSE:
+/// The common Builder interface.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: AnyObject {
@@ -31,77 +25,67 @@ internal protocol ___VARIABLE_productName___Builder: AnyObject {
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginListDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin List.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin List.
 public final class ___VARIABLE_productName___PluginListComponent: Component
 <
     ___VARIABLE_productName___PluginListDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
-         <Name>PluginComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
+     *      <Name>PluginComponent(parent: self)
+     *  }
+     *
      */
 }
 
-/**
- PURPOSE:
- The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
- */
+/// PURPOSE:
+/// The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
 internal typealias ___VARIABLE_productName___PluginListKeyType = String
 
-/**
- PURPOSE:
- To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
 internal typealias ___VARIABLE_productName___PluginListStateType = Void
 
-/**
- PURPOSE:
- The Plugin List protocol (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin List protocol (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___PluginList {
@@ -110,10 +94,8 @@ internal protocol ___VARIABLE_productName___PluginList {
     func create(key: ___VARIABLE_productName___PluginListKeyType) -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
 internal final class ___VARIABLE_productName___PluginListImp: PluginList
 <
     ___VARIABLE_productName___PluginListKeyType,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKit-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKit-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKit-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKit-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ViewControllableFlow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: AnyObject {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: AnyObject {
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKit-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKit-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKit-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKit-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKit-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKit-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKit-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKit-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKit-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKit-ViewController.txt
@@ -4,19 +4,15 @@ import Combine
 import Nodes
 import UIKit
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class ___VARIABLE_productName___ViewController: UIViewController, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKit-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKit-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitCreatedForPluginList-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitCreatedForPluginList-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitCreatedForPluginList-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitCreatedForPluginList-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ___VARIABLE_PluginListName___Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName___Builder {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName_
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitCreatedForPluginList-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitCreatedForPluginList-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitCreatedForPluginList-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitCreatedForPluginList-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitCreatedForPluginList-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitCreatedForPluginList-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitCreatedForPluginList-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitCreatedForPluginList-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitCreatedForPluginList-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitCreatedForPluginList-ViewController.txt
@@ -4,19 +4,15 @@ import Combine
 import Nodes
 import UIKit
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class ___VARIABLE_productName___ViewController: UIViewController, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitCreatedForPluginList-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitCreatedForPluginList-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUI-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUI-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUI-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUI-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ViewControllableFlow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: AnyObject {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: AnyObject {
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUI-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUI-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUI-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUI-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUI-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUI-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUI-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUI-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUI-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUI-ViewController.txt
@@ -4,19 +4,15 @@ import Combine
 import Nodes
 import SwiftUI
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class ___VARIABLE_productName___ViewController: UIHostingController
 <
     ___VARIABLE_productName___View
@@ -24,10 +20,8 @@ internal final class ___VARIABLE_productName___ViewController: UIHostingControll
 
 extension ___VARIABLE_productName___ViewController: ___VARIABLE_productName___ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct ___VARIABLE_productName___View {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUI-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUI-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUICreatedForPluginList-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUICreatedForPluginList-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUICreatedForPluginList-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUICreatedForPluginList-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ___VARIABLE_PluginListName___Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName___Builder {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName_
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUICreatedForPluginList-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUICreatedForPluginList-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUICreatedForPluginList-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUICreatedForPluginList-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUICreatedForPluginList-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUICreatedForPluginList-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUICreatedForPluginList-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUICreatedForPluginList-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUICreatedForPluginList-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUICreatedForPluginList-ViewController.txt
@@ -4,19 +4,15 @@ import Combine
 import Nodes
 import SwiftUI
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class ___VARIABLE_productName___ViewController: UIHostingController
 <
     ___VARIABLE_productName___View
@@ -24,10 +20,8 @@ internal final class ___VARIABLE_productName___ViewController: UIHostingControll
 
 extension ___VARIABLE_productName___ViewController: ___VARIABLE_productName___ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct ___VARIABLE_productName___View {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUICreatedForPluginList-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-UIKitSwiftUICreatedForPluginList-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-ViewInjected-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-ViewInjected-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-ViewInjected-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-ViewInjected-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = (___VARIABLE_productName___Listener, ___VARIABLE_productName___ViewControllable)
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: AnyObject {
@@ -117,10 +105,8 @@ internal protocol ___VARIABLE_productName___Builder: AnyObject {
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-ViewInjected-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-ViewInjected-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-ViewInjected-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-ViewInjected-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-ViewInjected-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-ViewInjected-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-ViewInjected-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-ViewInjected-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Worker-Worker.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-Worker-Worker.txt
@@ -3,17 +3,13 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- Encapsulates work to be performed by the Node.
- */
+/// PURPOSE:
+/// Encapsulates work to be performed by the Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Worker: Worker {}
 
-/**
- PURPOSE:
- Concrete implementation of the Worker.
- */
+/// PURPOSE:
+/// Concrete implementation of the Worker.
 internal final class ___VARIABLE_productName___WorkerImp: AbstractWorker
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKit-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKit-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKit-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKit-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ViewControllableFlow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: AnyObject {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: AnyObject {
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKit-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKit-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKit-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKit-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKit-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKit-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKit-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKit-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKit-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKit-ViewController.txt
@@ -4,19 +4,15 @@ import AppKit
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class ___VARIABLE_productName___ViewController: NSViewController, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKit-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKit-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitCreatedForPluginList-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitCreatedForPluginList-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitCreatedForPluginList-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitCreatedForPluginList-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ___VARIABLE_PluginListName___Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName___Builder {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName_
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitCreatedForPluginList-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitCreatedForPluginList-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitCreatedForPluginList-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitCreatedForPluginList-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitCreatedForPluginList-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitCreatedForPluginList-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitCreatedForPluginList-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitCreatedForPluginList-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitCreatedForPluginList-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitCreatedForPluginList-ViewController.txt
@@ -4,19 +4,15 @@ import AppKit
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class ___VARIABLE_productName___ViewController: NSViewController, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitCreatedForPluginList-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitCreatedForPluginList-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUI-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUI-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUI-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUI-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ViewControllableFlow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: AnyObject {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: AnyObject {
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUI-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUI-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUI-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUI-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUI-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUI-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUI-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUI-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUI-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUI-ViewController.txt
@@ -4,19 +4,15 @@ import Combine
 import Nodes
 import SwiftUI
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class ___VARIABLE_productName___ViewController: NSHostingController
 <
     ___VARIABLE_productName___View
@@ -24,10 +20,8 @@ internal final class ___VARIABLE_productName___ViewController: NSHostingControll
 
 extension ___VARIABLE_productName___ViewController: ___VARIABLE_productName___ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct ___VARIABLE_productName___View {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUI-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUI-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUICreatedForPluginList-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUICreatedForPluginList-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUICreatedForPluginList-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUICreatedForPluginList-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ___VARIABLE_PluginListName___Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName___Builder {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName_
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUICreatedForPluginList-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUICreatedForPluginList-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUICreatedForPluginList-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUICreatedForPluginList-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUICreatedForPluginList-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUICreatedForPluginList-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUICreatedForPluginList-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUICreatedForPluginList-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUICreatedForPluginList-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUICreatedForPluginList-ViewController.txt
@@ -4,19 +4,15 @@ import Combine
 import Nodes
 import SwiftUI
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class ___VARIABLE_productName___ViewController: NSHostingController
 <
     ___VARIABLE_productName___View
@@ -24,10 +20,8 @@ internal final class ___VARIABLE_productName___ViewController: NSHostingControll
 
 extension ___VARIABLE_productName___ViewController: ___VARIABLE_productName___ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct ___VARIABLE_productName___View {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUICreatedForPluginList-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-AppKitSwiftUICreatedForPluginList-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Custom-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Custom-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Custom-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Custom-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ViewControllableFlow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: AnyObject {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: AnyObject {
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Custom-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Custom-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Custom-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Custom-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Custom-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Custom-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Custom-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Custom-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Custom-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Custom-ViewController.txt
@@ -4,19 +4,15 @@ import Combine
 import CustomFramework
 import Nodes
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class ___VARIABLE_productName___ViewController: CustomViewController, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Custom-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Custom-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-CustomCreatedForPluginList-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-CustomCreatedForPluginList-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-CustomCreatedForPluginList-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-CustomCreatedForPluginList-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ___VARIABLE_PluginListName___Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName___Builder {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName_
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-CustomCreatedForPluginList-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-CustomCreatedForPluginList-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-CustomCreatedForPluginList-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-CustomCreatedForPluginList-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-CustomCreatedForPluginList-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-CustomCreatedForPluginList-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-CustomCreatedForPluginList-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-CustomCreatedForPluginList-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-CustomCreatedForPluginList-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-CustomCreatedForPluginList-ViewController.txt
@@ -4,19 +4,15 @@ import Combine
 import CustomFramework
 import Nodes
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class ___VARIABLE_productName___ViewController: CustomViewController, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-CustomCreatedForPluginList-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-CustomCreatedForPluginList-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Plugin-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Plugin-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-PluginList-PluginList.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-PluginList-PluginList.txt
@@ -3,26 +3,20 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The common Flow interface.
- */
+/// PURPOSE:
+/// The common Flow interface.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ViewControllableFlow {}
 
-/**
- PURPOSE:
- The common Listener interface.
- */
+/// PURPOSE:
+/// The common Listener interface.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The common Builder interface.
- */
+/// PURPOSE:
+/// The common Builder interface.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: AnyObject {
@@ -31,77 +25,67 @@ internal protocol ___VARIABLE_productName___Builder: AnyObject {
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin List that will be injected (not created by this Plugin List itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginListDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin List.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin List.
 public final class ___VARIABLE_productName___PluginListComponent: Component
 <
     ___VARIABLE_productName___PluginListDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
-         <Name>PluginComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>PluginComponentFactory() -> <Name>PluginComponent {
+     *      <Name>PluginComponent(parent: self)
+     *  }
+     *
      */
 }
 
-/**
- PURPOSE:
- The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
- */
+/// PURPOSE:
+/// The type used for the keys of the Plugin List (can be any `Hashable` type such as `String` or an enumeration).
 internal typealias ___VARIABLE_productName___PluginListKeyType = String
 
-/**
- PURPOSE:
- To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the plugins are enabled (can be any type relevant to the plugins).
 internal typealias ___VARIABLE_productName___PluginListStateType = Void
 
-/**
- PURPOSE:
- The Plugin List protocol (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin List protocol (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___PluginList {
@@ -110,10 +94,8 @@ internal protocol ___VARIABLE_productName___PluginList {
     func create(key: ___VARIABLE_productName___PluginListKeyType) -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin List providing the Plugin collection and (optionally) the creation order.
 internal final class ___VARIABLE_productName___PluginListImp: PluginList
 <
     ___VARIABLE_productName___PluginListKeyType,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKit-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKit-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKit-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKit-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ViewControllableFlow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: AnyObject {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: AnyObject {
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKit-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKit-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKit-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKit-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKit-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKit-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKit-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKit-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKit-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKit-ViewController.txt
@@ -4,19 +4,15 @@ import Combine
 import Nodes
 import UIKit
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class ___VARIABLE_productName___ViewController: UIViewController, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKit-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKit-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitCreatedForPluginList-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitCreatedForPluginList-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitCreatedForPluginList-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitCreatedForPluginList-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ___VARIABLE_PluginListName___Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName___Builder {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName_
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitCreatedForPluginList-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitCreatedForPluginList-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitCreatedForPluginList-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitCreatedForPluginList-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitCreatedForPluginList-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitCreatedForPluginList-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitCreatedForPluginList-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitCreatedForPluginList-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitCreatedForPluginList-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitCreatedForPluginList-ViewController.txt
@@ -4,19 +4,15 @@ import Combine
 import Nodes
 import UIKit
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Concrete implementation of the UI.
- */
+/// PURPOSE:
+/// Concrete implementation of the UI.
 internal final class ___VARIABLE_productName___ViewController: UIViewController, StateObserver {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitCreatedForPluginList-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitCreatedForPluginList-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUI-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUI-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUI-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUI-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ViewControllableFlow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: AnyObject {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: AnyObject {
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUI-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUI-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUI-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUI-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUI-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUI-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUI-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUI-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUI-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUI-ViewController.txt
@@ -4,19 +4,15 @@ import Combine
 import Nodes
 import SwiftUI
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class ___VARIABLE_productName___ViewController: UIHostingController
 <
     ___VARIABLE_productName___View
@@ -24,10 +20,8 @@ internal final class ___VARIABLE_productName___ViewController: UIHostingControll
 
 extension ___VARIABLE_productName___ViewController: ___VARIABLE_productName___ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct ___VARIABLE_productName___View {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUI-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUI-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUICreatedForPluginList-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUICreatedForPluginList-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUICreatedForPluginList-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUICreatedForPluginList-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: ___VARIABLE_PluginListName___Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = ___VARIABLE_productName___Listener
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
-         ChildComponent(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <nodeName>ComponentFactory() -> ChildComponent {
+     *      ChildComponent(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName___Builder {
@@ -116,10 +104,8 @@ internal protocol ___VARIABLE_productName___Builder: ___VARIABLE_PluginListName_
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUICreatedForPluginList-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUICreatedForPluginList-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUICreatedForPluginList-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUICreatedForPluginList-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUICreatedForPluginList-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUICreatedForPluginList-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUICreatedForPluginList-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUICreatedForPluginList-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUICreatedForPluginList-ViewController.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUICreatedForPluginList-ViewController.txt
@@ -4,19 +4,15 @@ import Combine
 import Nodes
 import SwiftUI
 
-/**
- PURPOSE:
- The interface that the View will speak to the Context through. Used for informing the Context of
- view events and user interactions.
- */
+/// PURPOSE:
+/// The interface that the View will speak to the Context through. Used for informing the Context of
+/// view events and user interactions.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Receiver: AnyObject {}
 
-/**
- PURPOSE:
- Host of the SwiftUI view.
- */
+/// PURPOSE:
+/// Host of the SwiftUI view.
 internal final class ___VARIABLE_productName___ViewController: UIHostingController
 <
     ___VARIABLE_productName___View
@@ -24,10 +20,8 @@ internal final class ___VARIABLE_productName___ViewController: UIHostingControll
 
 extension ___VARIABLE_productName___ViewController: ___VARIABLE_productName___ViewControllable {}
 
-/**
- PURPOSE:
- Concrete implementation of the View.
- */
+/// PURPOSE:
+/// Concrete implementation of the View.
 internal struct ___VARIABLE_productName___View {
 
     /// The view receiver.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUICreatedForPluginList-ViewState.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-UIKitSwiftUICreatedForPluginList-ViewState.txt
@@ -2,16 +2,12 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The view state of the view.
- */
+/// PURPOSE:
+/// The view state of the view.
 internal struct ___VARIABLE_productName___ViewState: Equatable {}
 
-/**
- PURPOSE:
- The factory used to create view state from the state of the Node.
- */
+/// PURPOSE:
+/// The factory used to create view state from the state of the Node.
 internal class ___VARIABLE_productName___ViewStateFactory: Nodes.Transform {
 
     /// The factory method in which state is transformed into view state.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-ViewInjected-Analytics.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-ViewInjected-Analytics.txt
@@ -1,28 +1,25 @@
 //___FILEHEADER___
 
 /*
- INSTRUCTIONS:
-
- Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
- class defined in this file (below).
-
- Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
- can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *  INSTRUCTIONS:
+ *
+ *  Inject an existing analytics tracker (or client), that is defined outside of the Node, into the
+ *  class defined in this file (below).
+ *
+ *  Inject the tracker (or client) via a protocol. The protocol for the injected tracker (or client)
+ *  can either be an existing one defined outside of the Node or can be a new one added to this file.
+ *
  */
 
-/**
- PURPOSE:
- The interface for analytics tracked by this Node.
-
- Add requirements to this protocol to provide analytics tracking methods for this Node.
- */
+/// PURPOSE:
+/// The interface for analytics tracked by this Node.
+///
+/// Add requirements to this protocol to provide analytics tracking methods for this Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Analytics: AnyObject {}
 
-/**
- PURPOSE:
- Custom analytics implementation for this Node.
- */
+/// PURPOSE:
+/// Custom analytics implementation for this Node.
 internal final class ___VARIABLE_productName___AnalyticsImp {}
 
 extension ___VARIABLE_productName___AnalyticsImp: ___VARIABLE_productName___Analytics {}

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-ViewInjected-Builder.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-ViewInjected-Builder.txt
@@ -4,72 +4,62 @@ import Combine
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- The interface of the Flow.
- */
+/// PURPOSE:
+/// The interface of the Flow.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Flow: Flow {}
 
-/**
- PURPOSE:
- Declares the dependencies required by this Node that will be injected (not created by this Node itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Node that will be injected (not created by this Node itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___Dependency: Dependency {}
 
-/**
- PURPOSE:
- A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency needed by the Builder (such as a Listener), passed in from the caller (i.e. is not on the DI graph).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicBuildDependency = (___VARIABLE_productName___Listener, ___VARIABLE_productName___ViewControllable)
 
-/**
- PURPOSE:
- A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
-
- Can be a tuple or struct containing multiple values when necessary.
- */
+/// PURPOSE:
+/// A dependency used by the Component itself, passed into the Component's initializer (in the Component factory).
+///
+/// Can be a tuple or struct containing multiple values when necessary.
 internal typealias ___VARIABLE_productName___DynamicComponentDependency = Void
 
 // MARK: - Component
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Node.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Node.
 public final class ___VARIABLE_productName___Component: Component
 <
     ___VARIABLE_productName___Dependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     private let dynamicDependency: ___VARIABLE_productName___DynamicComponentDependency
@@ -90,24 +80,22 @@ public final class ___VARIABLE_productName___Component: Component
     }
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 }
 
 // MARK: - Builder
 
-/**
- PURPOSE:
- The Builder interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Builder interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Builder: AnyObject {
@@ -117,10 +105,8 @@ internal protocol ___VARIABLE_productName___Builder: AnyObject {
     ) -> ___VARIABLE_productName___Flow
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Builder, where everything is created and associated.
- */
+/// PURPOSE:
+/// Concrete implementation of the Builder, where everything is created and associated.
 internal final class ___VARIABLE_productName___BuilderImp: AbstractBuilder
 <
     ___VARIABLE_productName___Component,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-ViewInjected-Context.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-ViewInjected-Context.txt
@@ -3,28 +3,22 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- The Context delegates callbacks to its (external) Listener, typically the parent Context.
- */
+/// PURPOSE:
+/// The Context delegates callbacks to its (external) Listener, typically the parent Context.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Listener: AnyObject {}
 
-/**
- PURPOSE:
- The interface that the Context will speak to the Flow through. Used to initiate navigation as
- an example.
- */
+/// PURPOSE:
+/// The interface that the Context will speak to the Flow through. Used to initiate navigation as
+/// an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___FlowInterface: Flow {}
 
-/**
- PURPOSE:
- Contains the business logic of the Node. The lifecycle of the Node is bookended between the
- `didBecomeActive` and `willResignActive` methods.
- */
+/// PURPOSE:
+/// Contains the business logic of the Node. The lifecycle of the Node is bookended between the
+/// `didBecomeActive` and `willResignActive` methods.
 internal final class ___VARIABLE_productName___ContextImp: AbstractContext
 <
     AnyCancellable

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-ViewInjected-Flow.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-ViewInjected-Flow.txt
@@ -2,29 +2,23 @@
 
 import Nodes
 
-/**
- PURPOSE:
- The interface that the Flow will speak to the Context through. Used for informing the Context of
- presentation lifecycle events, as an example.
- */
+/// PURPOSE:
+/// The interface that the Flow will speak to the Context through. Used for informing the Context of
+/// presentation lifecycle events, as an example.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ContextInterface: Context {}
 
-/**
- PURPOSE:
- The interface of the View used for presenting the View of child Nodes. May inherit additional base
- protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
- implementation as necessary.
- */
+/// PURPOSE:
+/// The interface of the View used for presenting the View of child Nodes. May inherit additional base
+/// protocols to add further pre-baked presentation behavior and/or add new methods for custom presentation
+/// implementation as necessary.
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___ViewControllable: ViewControllable {}
 
-/**
- PURPOSE:
- Responsible for presenting views and starting child Flows, and should not contain business logic.
- */
+/// PURPOSE:
+/// Responsible for presenting views and starting child Flows, and should not contain business logic.
 internal final class ___VARIABLE_productName___FlowImp: AbstractFlow
 <
     ___VARIABLE_productName___ContextInterface,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-ViewInjected-Plugin.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-ViewInjected-Plugin.txt
@@ -3,58 +3,54 @@
 import NeedleFoundation
 import Nodes
 
-/**
- PURPOSE:
- Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
- */
+/// PURPOSE:
+/// Declares the dependencies required by this Plugin that will be injected (not created by this Plugin itself).
 /// @mockable
 @MainActor
 public protocol ___VARIABLE_productName___PluginDependency: Dependency {}
 
-/**
- PURPOSE:
- Declares dependencies that are owned by this Plugin.
- */
+/// PURPOSE:
+/// Declares dependencies that are owned by this Plugin.
 public final class ___VARIABLE_productName___PluginComponent: Component
 <
     ___VARIABLE_productName___PluginDependency
 > {
 
     /*
-     Dependencies
-     ============
-
-     Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
-
-     fileprivate let example: Example = .init()
-
-     Whenever possible, for example when the dependency does not provide shared state, define the property as a
-     factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
-     Needle compatibility whenever the access control is increased.
-
-     fileprivate var exampleFactory: Example {
-         Example()
-     }
-
-     When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
-     that always returns the same instance from a computed property.
-
-     fileprivate var example: Example {
-         shared { Example(otherDependency: dependency.otherDependency) }
-     }
-
+     *  Dependencies
+     *  ============
+     *
+     *  Declare dependencies as 'fileprivate' properties (increasing access control only as necessary).
+     *
+     *  fileprivate let example: Example = .init()
+     *
+     *  Whenever possible, for example when the dependency does not provide shared state, define the property as a
+     *  factory that always returns a new instance. Factory properties are preferred over factory methods to ensure
+     *  Needle compatibility whenever the access control is increased.
+     *
+     *  fileprivate var exampleFactory: Example {
+     *      Example()
+     *  }
+     *
+     *  When shared state is desired but the dependency depends on another dependency, use the `shared` helper method
+     *  that always returns the same instance from a computed property.
+     *
+     *  fileprivate var example: Example {
+     *      shared { Example(otherDependency: dependency.otherDependency) }
+     *  }
+     *
      */
 
     /*
-     Child Components
-     ================
-
-     Declare child component factories as 'fileprivate' methods.
-
-     fileprivate func <name>ComponentFactory() -> <Name>Component {
-         <Name>Component(parent: self)
-     }
-
+     *  Child Components
+     *  ================
+     *
+     *  Declare child component factories as 'fileprivate' methods.
+     *
+     *  fileprivate func <name>ComponentFactory() -> <Name>Component {
+     *      <Name>Component(parent: self)
+     *  }
+     *
      */
 
     fileprivate func componentFactory() -> ___VARIABLE_productName___Component {
@@ -62,26 +58,20 @@ public final class ___VARIABLE_productName___PluginComponent: Component
     }
 }
 
-/**
- PURPOSE:
- To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
- */
+/// PURPOSE:
+/// To provide additional state used in determining if the Plugin is enabled (can be any type relevant to the Plugin).
 internal typealias ___VARIABLE_productName___PluginStateType = Void
 
-/**
- PURPOSE:
- The Plugin interface (available to mock for testability).
- */
+/// PURPOSE:
+/// The Plugin interface (available to mock for testability).
 /// @mockable
 @MainActor
 internal protocol ___VARIABLE_productName___Plugin {
     func create() -> ___VARIABLE_productName___Builder?
 }
 
-/**
- PURPOSE:
- Concrete implementation of the Plugin.
- */
+/// PURPOSE:
+/// Concrete implementation of the Plugin.
 internal final class ___VARIABLE_productName___PluginImp: Plugin
 <
     ___VARIABLE_productName___PluginComponent,

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-ViewInjected-State.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-ViewInjected-State.txt
@@ -1,9 +1,7 @@
 //___FILEHEADER___
 
-/**
- PURPOSE:
- The state of the Node.
- */
+/// PURPOSE:
+/// The state of the Node.
 internal struct ___VARIABLE_productName___State: Equatable {
 
     internal static func initialState() -> Self {

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Worker-Worker.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-Worker-Worker.txt
@@ -3,17 +3,13 @@
 import Combine
 import Nodes
 
-/**
- PURPOSE:
- Encapsulates work to be performed by the Node.
- */
+/// PURPOSE:
+/// Encapsulates work to be performed by the Node.
 /// @mockable
 internal protocol ___VARIABLE_productName___Worker: Worker {}
 
-/**
- PURPOSE:
- Concrete implementation of the Worker.
- */
+/// PURPOSE:
+/// Concrete implementation of the Worker.
 internal final class ___VARIABLE_productName___WorkerImp: AbstractWorker
 <
     AnyCancellable


### PR DESCRIPTION
Update Nodes to use triple slash comments rather than block based comments

- Update Nodes to use triple slash comments rather than block based comments (this matches Xcode’s documentation style using Editor -> Structure -> Add Documentation)
- This matches the style provided with the official swift-format in Xcode 16 with the default rule of UseTripleSlashForDocumentationComments being set to true.