### PR TITLE
Compare imports as sorted array

### DIFF
--- a/Tests/NodesGeneratorTests/StencilTemplateTests.swift
+++ b/Tests/NodesGeneratorTests/StencilTemplateTests.swift
@@ -251,7 +251,7 @@ final class StencilTemplateTests: XCTestCase, TestFactories {
         let config: Config = givenConfig()
         for stencilTemplate in StencilTemplate.allCases {
             for uiFramework in config.uiFrameworks {
-                let imports: [String] = Array(stencilTemplate.imports(with: config, including: uiFramework)).sorted()
+                let imports: [String] = stencilTemplate.imports(with: config, including: uiFramework).sortedImports()
                 let uiFrameworkImport: String
                 switch uiFramework.kind {
                 case .appKit:
@@ -377,7 +377,7 @@ final class StencilTemplateTests: XCTestCase, TestFactories {
     func testImportsWithConfig() {
         let config: Config = givenConfig()
         for stencilTemplate in StencilTemplate.allCases {
-            let imports: [String] = Array(stencilTemplate.imports(with: config)).sorted()
+            let imports: [String] = stencilTemplate.imports(with: config).sortedImports()
             switch stencilTemplate {
             case .analytics:
                 expect(imports) == [


### PR DESCRIPTION
Since `imports(with:including:)` returns a `Set`, the expected value created using array literal syntax in the expectation against `imports` is also a `Set`. Sets automatically de-dupe the contents of the array literal. That is why [this test did not fail](https://github.com/TinderApp/Nodes/pull/840#discussion_r1790973698). By converting the actual value to an `Array`, the expected value also becomes an `Array` and any duplicate values will not be removed.

Arrays are ordered, therefore, we need to sort the imports to make the test predictable as `Set` is unordered.

The `uiFrameworkImport` is dynamic so we need to add an additional handling for that case.