### PR TITLE
Add Swift Package Index configuration

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,3 @@
+version: 1
+external_links:
+  documentation: https://Tinder.github.io/Nodes/documentation/nodes


### PR DESCRIPTION
[Swift Package Index Documentation](https://swiftpackageindex.com/swiftpackageindex/spimanifest/1.1.2/documentation/spimanifest/commonusecases#Configure-a-documentation-URL-for-existing-documentation)