### PR TITLE
Added New Interface Stencil To House Node Protocols

### DIFF
--- a/Sources/NodesGenerator/Resources/Stencils/Interface-SwiftUI.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Interface-SwiftUI.stencil
@@ -44,19 +44,11 @@ internal protocol {{ node_name }}Flow: Flow {}
 @MainActor
 {% if plugin_list_name %}
 internal protocol {{ node_name }}Builder: {{ plugin_list_name }}Builder {
+{% else %}
+internal protocol {{ node_name }}Builder: AnyObject {
+{% endif %}
     func build(
         withListener listener: {{ node_name }}Listener
     ) -> {{ node_name }}Flow
 }
-{% else %}
-internal protocol {{ node_name }}Builder: AnyObject {
-    {% if node_name == "App" %}
-    func build() -> {{ node_name }}Flow
-    {% else %}
-    func build(
-        withListener listener: {{ node_name }}Listener{% if not owns_view %}{{ ',' }}
-        viewController: {{ node_name }}ViewControllable{% endif +%}
-    ) -> {{ node_name }}Flow
-    {% endif %}
-}
-{% endif %}
+

--- a/Sources/NodesGenerator/Resources/Stencils/Interface-SwiftUI.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Interface-SwiftUI.stencil
@@ -51,4 +51,3 @@ internal protocol {{ node_name }}Builder: AnyObject {
         withListener listener: {{ node_name }}Listener
     ) -> {{ node_name }}Flow
 }
-

--- a/Sources/NodesGenerator/Resources/Stencils/Interface-SwiftUI.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Interface-SwiftUI.stencil
@@ -7,6 +7,7 @@ import {{ import }}
 {% endif %}
 
 // This file defines the protocols and types in the interface requiring public ACL for use in another module.
+{% if node_name != "App" %}
 
 // MARK: - Listener
 
@@ -20,20 +21,11 @@ internal protocol {{ node_name }}Listener: AnyObject {}
 
 /// @mockable
 @MainActor
-{% if owns_view %}
 {% if plugin_list_name %}
 internal protocol {{ node_name }}Flow: {{ plugin_list_name }}Flow {}
 {% else %}
 internal protocol {{ node_name }}Flow: {{ view_controllable_flow_type }} {}
 {% endif %}
-{% elif node_name == "WindowScene" %}
-internal protocol {{ node_name }}Flow: Flow {
-    func getViewController() -> {{ node_name }}ViewControllable
-}
-{% else %}
-internal protocol {{ node_name }}Flow: Flow {}
-{% endif %}
-{% if node_name != "App" %}
 
 // MARK: - Builder
 
@@ -44,10 +36,19 @@ internal protocol {{ node_name }}Flow: Flow {}
 @MainActor
 {% if plugin_list_name %}
 internal protocol {{ node_name }}Builder: {{ plugin_list_name }}Builder {
-{% else %}
-internal protocol {{ node_name }}Builder: AnyObject {
-{% endif %}
     func build(
         withListener listener: {{ node_name }}Listener
     ) -> {{ node_name }}Flow
 }
+{% else %}
+internal protocol {{ node_name }}Builder: AnyObject {
+    {% if node_name == "App" %}
+    func build() -> {{ node_name }}Flow
+    {% else %}
+    func build(
+        withListener listener: {{ node_name }}Listener{% if not owns_view %}{{ ',' }}
+        viewController: {{ node_name }}ViewControllable{% endif +%}
+    ) -> {{ node_name }}Flow
+    {% endif %}
+}
+{% endif %}

--- a/Sources/NodesGenerator/Resources/Stencils/Interface-SwiftUI.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Interface-SwiftUI.stencil
@@ -36,19 +36,10 @@ internal protocol {{ node_name }}Flow: {{ view_controllable_flow_type }} {}
 @MainActor
 {% if plugin_list_name %}
 internal protocol {{ node_name }}Builder: {{ plugin_list_name }}Builder {
+{% else %}
+internal protocol {{ node_name }}Builder: AnyObject {
+{% endif %}
     func build(
         withListener listener: {{ node_name }}Listener
     ) -> {{ node_name }}Flow
 }
-{% else %}
-internal protocol {{ node_name }}Builder: AnyObject {
-    {% if node_name == "App" %}
-    func build() -> {{ node_name }}Flow
-    {% else %}
-    func build(
-        withListener listener: {{ node_name }}Listener{% if not owns_view %}{{ ',' }}
-        viewController: {{ node_name }}ViewControllable{% endif +%}
-    ) -> {{ node_name }}Flow
-    {% endif %}
-}
-{% endif %}

--- a/Sources/NodesGenerator/Resources/Stencils/Interface.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Interface.stencil
@@ -8,7 +8,6 @@ import {{ import }}
 
 // This file defines the protocols and types in the interface requiring public ACL for use in another module.
 
-
 // MARK: - Builder
 
 {% if is_periphery_comment_enabled %}

--- a/Sources/NodesGenerator/Resources/Stencils/Interface.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Interface.stencil
@@ -6,6 +6,9 @@ import {{ import }}
 {% endfor %}
 {% endif %}
 
+// This file defines the protocols and types in the interface requiring public ACL for use in another module.
+
+
 // MARK: - Builder
 
 {% if is_periphery_comment_enabled %}

--- a/Sources/NodesGenerator/Resources/Stencils/Interface.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Interface.stencil
@@ -1,0 +1,59 @@
+//{{ file_header }}
+{% if interface_imports %}
+
+{% for import in interface_imports %}
+import {{ import }}
+{% endfor %}
+{% endif %}
+
+// MARK: - Builder
+
+{% if is_periphery_comment_enabled %}
+// periphery:ignore
+{% endif %}
+/// @mockable
+@MainActor
+{% if plugin_list_name %}
+internal protocol {{ node_name }}Builder: {{ plugin_list_name }}Builder {
+    func build(
+        withListener listener: {{ node_name }}Listener
+    ) -> {{ node_name }}Flow
+}
+{% else %}
+internal protocol {{ node_name }}Builder: AnyObject {
+    {% if node_name == "App" %}
+    func build() -> {{ node_name }}Flow
+    {% else %}
+    func build(
+        withListener listener: {{ node_name }}Listener{% if not owns_view %}{{ ',' }}
+        viewController: {{ node_name }}ViewControllable{% endif +%}
+    ) -> {{ node_name }}Flow
+    {% endif %}
+}
+{% endif %}
+
+// MARK: - Flow
+
+/// @mockable
+@MainActor
+{% if owns_view %}
+{% if plugin_list_name %}
+internal protocol {{ node_name }}Flow: {{ plugin_list_name }}Flow {}
+{% else %}
+internal protocol {{ node_name }}Flow: {{ view_controllable_flow_type }} {}
+{% endif %}
+{% elif node_name == "WindowScene" %}
+internal protocol {{ node_name }}Flow: Flow {
+    func getViewController() -> {{ node_name }}ViewControllable
+}
+{% else %}
+internal protocol {{ node_name }}Flow: Flow {}
+{% endif %}
+
+// MARK: - Listener
+
+/// Defines the delegate protocol through which the `Context` interfaces with its listener.
+/// @mockable
+@MainActor
+internal protocol {{ node_name }}Listener: AnyObject {}
+{% endif %}

--- a/Sources/NodesGenerator/Resources/Stencils/Interface.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Interface.stencil
@@ -49,6 +49,7 @@ internal protocol {{ node_name }}Flow: Flow {
 {% else %}
 internal protocol {{ node_name }}Flow: Flow {}
 {% endif %}
+{% if node_name != "App" %}
 
 // MARK: - Listener
 

--- a/Sources/NodesGenerator/Resources/Stencils/Interface.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/Interface.stencil
@@ -7,6 +7,7 @@ import {{ import }}
 {% endif %}
 
 // This file defines the protocols and types in the interface requiring public ACL for use in another module.
+{% if node_name != "App" %}
 
 // MARK: - Listener
 
@@ -33,7 +34,6 @@ internal protocol {{ node_name }}Flow: Flow {
 {% else %}
 internal protocol {{ node_name }}Flow: Flow {}
 {% endif %}
-{% if node_name != "App" %}
 
 // MARK: - Builder
 


### PR DESCRIPTION
This PR introduces a new file, Interface.swift, which is created alongside your Node.

Interface.swift defines public protocols required for your Node to be accessible from other modules. You can leave this file in its default location or move it to a shared location for easier module imports, enabling seamless dependency injection.