### PR TITLE
Added Plugin Interface File

### DIFF
--- a/Sources/NodesGenerator/Resources/Stencils/PluginInterface.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/PluginInterface.stencil
@@ -1,0 +1,22 @@
+//{{ file_header }}
+{% if plugin_interface_imports %}
+
+{% for import in plugin_interface_imports %}
+import {{ import }}
+{% endfor %}
+{% endif %}
+
+// MARK: - Plugin
+
+/// Dynamic state from the caller provided to the plugin to use in determining whether it is enabled.
+/// - NOTE: An alias to a tuple is supported.
+internal typealias {{ plugin_name }}PluginStateType = Void
+
+{% if is_periphery_comment_enabled %}
+// periphery:ignore
+{% endif %}
+/// @mockable
+@MainActor
+internal protocol {{ plugin_name }}Plugin {
+    func create() -> {{ plugin_name }}Builder?
+}

--- a/Sources/NodesGenerator/Resources/Stencils/PluginInterface.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/PluginInterface.stencil
@@ -6,7 +6,7 @@ import {{ import }}
 {% endfor %}
 {% endif %}
 
-// MARK: - Plugin
+// This file defines the protocols and types in the plugin interface requiring public ACL for use in another module.
 
 /// Dynamic state from the caller provided to the plugin to use in determining whether it is enabled.
 /// - NOTE: An alias to a tuple is supported.


### PR DESCRIPTION
This PR creates a new file called PluginInterface.swift. This file houses the protocols that can be made public so your Node can be used in other modules in your codebase, when your Node is using a Plugin.
The other protocols needed to use a Node across modules can be found in the Interface.swift file. This was added in this PR: https://github.com/Tinder/Nodes/pull/880