### PR TITLE
Added PluginListInterface.stencil File

### DIFF
--- a/Sources/NodesGenerator/Resources/Stencils/PluginListInterface.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/PluginListInterface.stencil
@@ -6,7 +6,7 @@ import {{ import }}
 {% endfor %}
 {% endif %}
 
-// This file defines the protocols and types in the PluginList interface requiring public ACL for use in another module.
+// This file defines the protocols and types in the Plugin List interface requiring public ACL for use in another module.
 
 /// Declares the type of key used to identify plugins within the collection.
 /// - NOTE: May be any ``Hashable`` type such as ``String`` or an enumeration.

--- a/Sources/NodesGenerator/Resources/Stencils/PluginListInterface.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/PluginListInterface.stencil
@@ -1,0 +1,28 @@
+//{{ file_header }}
+{% if plugin_list_interface_imports %}
+
+{% for import in plugin_list_interface_imports %}
+import {{ import }}
+{% endfor %}
+{% endif %}
+
+// This file defines the protocols and types in the PluginList interface requiring public ACL for use in another module.
+
+/// Declares the type of key used to identify plugins within the collection.
+/// - NOTE: May be any ``Hashable`` type such as ``String`` or an enumeration.
+internal typealias {{ plugin_list_name }}PluginListKeyType = String
+
+/// Dynamic state from the caller provided to the plugins to use in determining whether they are enabled.
+/// - NOTE: An alias to a tuple is supported.
+internal typealias {{ plugin_list_name }}PluginListStateType = Void
+
+{% if is_periphery_comment_enabled %}
+// periphery:ignore
+{% endif %}
+/// @mockable
+@MainActor
+internal protocol {{ plugin_list_name }}PluginList {
+    func createAll() -> [{{ plugin_list_name }}Builder]
+    func create() -> {{ plugin_list_name }}Builder?
+    func create(key: {{ plugin_list_name }}PluginListKeyType) -> {{ plugin_list_name }}Builder?
+}


### PR DESCRIPTION
This adds a new file called PluginListInterface. This will house the protocols that will need to be available outside your module for this PluginList and node to be used in another module.

More details here: https://github.com/Tinder/Nodes/pull/880