### PR TITLE
Moved Protocol Declarations Out Of PluginList Files

### DIFF
--- a/Sources/NodesGenerator/Resources/Stencils/PluginInterface.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/PluginInterface.stencil
@@ -10,6 +10,31 @@ import {{ import }}
  This file contains the protocols and types of the plugin interface requiring public ACL for use in another module.
  */
 
+ {% if is_periphery_comment_enabled %}
+// periphery:ignore
+{% endif %}
+/// @mockable
+@MainActor
+internal protocol {{ plugin_list_name }}Flow: {{ view_controllable_flow_type }} {}
+
+{% if is_periphery_comment_enabled %}
+// periphery:ignore
+{% endif %}
+/// @mockable
+@MainActor
+internal protocol {{ plugin_list_name }}Listener: AnyObject {}
+
+{% if is_periphery_comment_enabled %}
+// periphery:ignore
+{% endif %}
+/// @mockable
+@MainActor
+internal protocol {{ plugin_list_name }}Builder: AnyObject {
+    func build(
+        withListener listener: {{ plugin_list_name }}Listener
+    ) -> {{ plugin_list_name }}Flow
+}
+
 /// Dynamic state from the caller provided to the plugin to use in determining whether it is enabled.
 /// - NOTE: An alias to a tuple is supported.
 internal typealias {{ plugin_name }}PluginStateType = Void

--- a/Sources/NodesGenerator/Resources/Stencils/PluginInterface.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/PluginInterface.stencil
@@ -10,31 +10,6 @@ import {{ import }}
  This file contains the protocols and types of the plugin interface requiring public ACL for use in another module.
  */
 
- {% if is_periphery_comment_enabled %}
-// periphery:ignore
-{% endif %}
-/// @mockable
-@MainActor
-internal protocol {{ plugin_list_name }}Flow: {{ view_controllable_flow_type }} {}
-
-{% if is_periphery_comment_enabled %}
-// periphery:ignore
-{% endif %}
-/// @mockable
-@MainActor
-internal protocol {{ plugin_list_name }}Listener: AnyObject {}
-
-{% if is_periphery_comment_enabled %}
-// periphery:ignore
-{% endif %}
-/// @mockable
-@MainActor
-internal protocol {{ plugin_list_name }}Builder: AnyObject {
-    func build(
-        withListener listener: {{ plugin_list_name }}Listener
-    ) -> {{ plugin_list_name }}Flow
-}
-
 /// Dynamic state from the caller provided to the plugin to use in determining whether it is enabled.
 /// - NOTE: An alias to a tuple is supported.
 internal typealias {{ plugin_name }}PluginStateType = Void

--- a/Sources/NodesGenerator/Resources/Stencils/PluginList.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/PluginList.stencil
@@ -6,31 +6,6 @@ import {{ import }}
 {% endfor %}
 {% endif %}
 
-{% if is_periphery_comment_enabled %}
-// periphery:ignore
-{% endif %}
-/// @mockable
-@MainActor
-internal protocol {{ plugin_list_name }}Flow: {{ view_controllable_flow_type }} {}
-
-{% if is_periphery_comment_enabled %}
-// periphery:ignore
-{% endif %}
-/// @mockable
-@MainActor
-internal protocol {{ plugin_list_name }}Listener: AnyObject {}
-
-{% if is_periphery_comment_enabled %}
-// periphery:ignore
-{% endif %}
-/// @mockable
-@MainActor
-internal protocol {{ plugin_list_name }}Builder: AnyObject {
-    func build(
-        withListener listener: {{ plugin_list_name }}Listener
-    ) -> {{ plugin_list_name }}Flow
-}
-
 // MARK: - Dependency
 
 /// Declares the dependencies required by the component. A code-generated conforming object is made available to the

--- a/Sources/NodesGenerator/Resources/Stencils/PluginListInterface.stencil
+++ b/Sources/NodesGenerator/Resources/Stencils/PluginListInterface.stencil
@@ -10,6 +10,32 @@ import {{ import }}
  This file contains the protocols and types of the plugin list interface requiring public ACL for use in another module.
  */
 
+/// Defines the delegate protocol through which the `Context` interfaces with its listener.
+{% if is_periphery_comment_enabled %}
+// periphery:ignore
+{% endif %}
+/// @mockable
+@MainActor
+internal protocol {{ plugin_list_name }}Listener: AnyObject {}
+
+{% if is_periphery_comment_enabled %}
+// periphery:ignore
+{% endif %}
+/// @mockable
+@MainActor
+internal protocol {{ plugin_list_name }}Flow: {{ view_controllable_flow_type }} {}
+
+{% if is_periphery_comment_enabled %}
+// periphery:ignore
+{% endif %}
+/// @mockable
+@MainActor
+internal protocol {{ plugin_list_name }}Builder: AnyObject {
+    func build(
+        withListener listener: {{ plugin_list_name }}Listener
+    ) -> {{ plugin_list_name }}Flow
+}
+
 /// Declares the type of key used to identify plugins within the collection.
 /// - NOTE: May be any ``Hashable`` type such as ``String`` or an enumeration.
 internal typealias {{ plugin_list_name }}PluginListKeyType = String

--- a/Sources/NodesGenerator/StencilTemplate.swift
+++ b/Sources/NodesGenerator/StencilTemplate.swift
@@ -304,6 +304,7 @@ public enum StencilTemplate: CustomStringConvertible, Equatable, Sendable {
                 .union(config.pluginListImports)
         case .pluginListInterface:
             config.baseImports
+                .union(["Nodes"])
         case .pluginListTests:
             config.baseTestImports
                 .union(["NodesTesting"])

--- a/Tests/NodesGeneratorTests/StencilTemplateTests.swift
+++ b/Tests/NodesGeneratorTests/StencilTemplateTests.swift
@@ -368,7 +368,8 @@ final class StencilTemplateTests: XCTestCase, TestFactories {
                     ]
                 case .pluginListInterface:
                     expect(imports) == [
-                        "<baseImport>"
+                        "<baseImport>",
+                        "Nodes"
                     ]
                 case .pluginListTests:
                     expect(imports) == [
@@ -494,7 +495,8 @@ final class StencilTemplateTests: XCTestCase, TestFactories {
                 ]
             case .pluginListInterface:
                 expect(imports) == [
-                    "<baseImport>"
+                    "<baseImport>",
+                    "Nodes"
                 ]
             case .pluginListTests:
                 expect(imports) == [

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginList-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginList-mockCount-0.txt
@@ -1,21 +1,5 @@
 //<fileHeader>
 
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
-
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Listener: AnyObject {}
-
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Builder: AnyObject {
-    func build(
-        withListener listener: <pluginListName>Listener
-    ) -> <pluginListName>Flow
-}
-
 // MARK: - Dependency
 
 /// Declares the dependencies required by the component. A code-generated conforming object is made available to the

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginList-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginList-mockCount-1.txt
@@ -2,25 +2,6 @@
 
 import <pluginListImport>
 
-// periphery:ignore
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
-
-// periphery:ignore
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Listener: AnyObject {}
-
-// periphery:ignore
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Builder: AnyObject {
-    func build(
-        withListener listener: <pluginListName>Listener
-    ) -> <pluginListName>Flow
-}
-
 // MARK: - Dependency
 
 /// Declares the dependencies required by the component. A code-generated conforming object is made available to the

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginList-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginList-mockCount-2.txt
@@ -3,25 +3,6 @@
 import <pluginListImport1>
 import <pluginListImport2>
 
-// periphery:ignore
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
-
-// periphery:ignore
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Listener: AnyObject {}
-
-// periphery:ignore
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Builder: AnyObject {
-    func build(
-        withListener listener: <pluginListName>Listener
-    ) -> <pluginListName>Flow
-}
-
 // MARK: - Dependency
 
 /// Declares the dependencies required by the component. A code-generated conforming object is made available to the

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginListInterface-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginListInterface-mockCount-0.txt
@@ -4,6 +4,23 @@
  This file contains the protocols and types of the plugin list interface requiring public ACL for use in another module.
  */
 
+/// Defines the delegate protocol through which the `Context` interfaces with its listener.
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Listener: AnyObject {}
+
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
+
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Builder: AnyObject {
+    func build(
+        withListener listener: <pluginListName>Listener
+    ) -> <pluginListName>Flow
+}
+
 /// Declares the type of key used to identify plugins within the collection.
 /// - NOTE: May be any ``Hashable`` type such as ``String`` or an enumeration.
 internal typealias <pluginListName>PluginListKeyType = String

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginListInterface-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginListInterface-mockCount-1.txt
@@ -6,6 +6,26 @@ import <pluginListInterfaceImport>
  This file contains the protocols and types of the plugin list interface requiring public ACL for use in another module.
  */
 
+/// Defines the delegate protocol through which the `Context` interfaces with its listener.
+// periphery:ignore
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Listener: AnyObject {}
+
+// periphery:ignore
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
+
+// periphery:ignore
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Builder: AnyObject {
+    func build(
+        withListener listener: <pluginListName>Listener
+    ) -> <pluginListName>Flow
+}
+
 /// Declares the type of key used to identify plugins within the collection.
 /// - NOTE: May be any ``Hashable`` type such as ``String`` or an enumeration.
 internal typealias <pluginListName>PluginListKeyType = String

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginListInterface-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList.PluginListInterface-mockCount-2.txt
@@ -7,6 +7,26 @@ import <pluginListInterfaceImport2>
  This file contains the protocols and types of the plugin list interface requiring public ACL for use in another module.
  */
 
+/// Defines the delegate protocol through which the `Context` interfaces with its listener.
+// periphery:ignore
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Listener: AnyObject {}
+
+// periphery:ignore
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
+
+// periphery:ignore
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Builder: AnyObject {
+    func build(
+        withListener listener: <pluginListName>Listener
+    ) -> <pluginListName>Flow
+}
+
 /// Declares the type of key used to identify plugins within the collection.
 /// - NOTE: May be any ``Hashable`` type such as ``String`` or an enumeration.
 internal typealias <pluginListName>PluginListKeyType = String

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginList-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginList-mockCount-0.txt
@@ -1,21 +1,5 @@
 //<fileHeader>
 
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
-
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Listener: AnyObject {}
-
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Builder: AnyObject {
-    func build(
-        withListener listener: <pluginListName>Listener
-    ) -> <pluginListName>Flow
-}
-
 // MARK: - Dependency
 
 /// Declares the dependencies required by the component. A code-generated conforming object is made available to the

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginList-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginList-mockCount-1.txt
@@ -2,25 +2,6 @@
 
 import <pluginListImport>
 
-// periphery:ignore
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
-
-// periphery:ignore
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Listener: AnyObject {}
-
-// periphery:ignore
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Builder: AnyObject {
-    func build(
-        withListener listener: <pluginListName>Listener
-    ) -> <pluginListName>Flow
-}
-
 // MARK: - Dependency
 
 /// Declares the dependencies required by the component. A code-generated conforming object is made available to the

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginList-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginList-mockCount-2.txt
@@ -3,25 +3,6 @@
 import <pluginListImport1>
 import <pluginListImport2>
 
-// periphery:ignore
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
-
-// periphery:ignore
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Listener: AnyObject {}
-
-// periphery:ignore
-/// @mockable
-@MainActor
-internal protocol <pluginListName>Builder: AnyObject {
-    func build(
-        withListener listener: <pluginListName>Listener
-    ) -> <pluginListName>Flow
-}
-
 // MARK: - Dependency
 
 /// Declares the dependencies required by the component. A code-generated conforming object is made available to the

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginListInterface-mockCount-0.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginListInterface-mockCount-0.txt
@@ -4,6 +4,23 @@
  This file contains the protocols and types of the plugin list interface requiring public ACL for use in another module.
  */
 
+/// Defines the delegate protocol through which the `Context` interfaces with its listener.
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Listener: AnyObject {}
+
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
+
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Builder: AnyObject {
+    func build(
+        withListener listener: <pluginListName>Listener
+    ) -> <pluginListName>Flow
+}
+
 /// Declares the type of key used to identify plugins within the collection.
 /// - NOTE: May be any ``Hashable`` type such as ``String`` or an enumeration.
 internal typealias <pluginListName>PluginListKeyType = String

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginListInterface-mockCount-1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginListInterface-mockCount-1.txt
@@ -6,6 +6,26 @@ import <pluginListInterfaceImport>
  This file contains the protocols and types of the plugin list interface requiring public ACL for use in another module.
  */
 
+/// Defines the delegate protocol through which the `Context` interfaces with its listener.
+// periphery:ignore
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Listener: AnyObject {}
+
+// periphery:ignore
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
+
+// periphery:ignore
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Builder: AnyObject {
+    func build(
+        withListener listener: <pluginListName>Listener
+    ) -> <pluginListName>Flow
+}
+
 /// Declares the type of key used to identify plugins within the collection.
 /// - NOTE: May be any ``Hashable`` type such as ``String`` or an enumeration.
 internal typealias <pluginListName>PluginListKeyType = String

--- a/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginListInterface-mockCount-2.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/StencilRendererTests/testRenderPluginList_withTests.PluginListInterface-mockCount-2.txt
@@ -7,6 +7,26 @@ import <pluginListInterfaceImport2>
  This file contains the protocols and types of the plugin list interface requiring public ACL for use in another module.
  */
 
+/// Defines the delegate protocol through which the `Context` interfaces with its listener.
+// periphery:ignore
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Listener: AnyObject {}
+
+// periphery:ignore
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Flow: <viewControllableFlowType> {}
+
+// periphery:ignore
+/// @mockable
+@MainActor
+internal protocol <pluginListName>Builder: AnyObject {
+    func build(
+        withListener listener: <pluginListName>Listener
+    ) -> <pluginListName>Flow
+}
+
 /// Declares the type of key used to identify plugins within the collection.
 /// - NOTE: May be any ``Hashable`` type such as ``String`` or an enumeration.
 internal typealias <pluginListName>PluginListKeyType = String

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-PluginList-PluginList.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-PluginList-PluginList.txt
@@ -3,22 +3,6 @@
 import NeedleFoundation
 import Nodes
 
-/// @mockable
-@MainActor
-internal protocol ___VARIABLE_productName___Flow: ViewControllableFlow {}
-
-/// @mockable
-@MainActor
-internal protocol ___VARIABLE_productName___Listener: AnyObject {}
-
-/// @mockable
-@MainActor
-internal protocol ___VARIABLE_productName___Builder: AnyObject {
-    func build(
-        withListener listener: ___VARIABLE_productName___Listener
-    ) -> ___VARIABLE_productName___Flow
-}
-
 // MARK: - Dependency
 
 /// Declares the dependencies required by the component. A code-generated conforming object is made available to the

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-PluginList-PluginListInterface.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithIdentifier.Contents-PluginList-PluginListInterface.txt
@@ -1,8 +1,27 @@
 //___FILEHEADER___
 
+import Nodes
+
 /*
  This file contains the protocols and types of the plugin list interface requiring public ACL for use in another module.
  */
+
+/// Defines the delegate protocol through which the `Context` interfaces with its listener.
+/// @mockable
+@MainActor
+internal protocol ___VARIABLE_productName___Listener: AnyObject {}
+
+/// @mockable
+@MainActor
+internal protocol ___VARIABLE_productName___Flow: ViewControllableFlow {}
+
+/// @mockable
+@MainActor
+internal protocol ___VARIABLE_productName___Builder: AnyObject {
+    func build(
+        withListener listener: ___VARIABLE_productName___Listener
+    ) -> ___VARIABLE_productName___Flow
+}
 
 /// Declares the type of key used to identify plugins within the collection.
 /// - NOTE: May be any ``Hashable`` type such as ``String`` or an enumeration.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-PluginList-PluginList.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-PluginList-PluginList.txt
@@ -3,22 +3,6 @@
 import NeedleFoundation
 import Nodes
 
-/// @mockable
-@MainActor
-internal protocol ___VARIABLE_productName___Flow: ViewControllableFlow {}
-
-/// @mockable
-@MainActor
-internal protocol ___VARIABLE_productName___Listener: AnyObject {}
-
-/// @mockable
-@MainActor
-internal protocol ___VARIABLE_productName___Builder: AnyObject {
-    func build(
-        withListener listener: ___VARIABLE_productName___Listener
-    ) -> ___VARIABLE_productName___Flow
-}
-
 // MARK: - Dependency
 
 /// Declares the dependencies required by the component. A code-generated conforming object is made available to the

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-PluginList-PluginListInterface.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateGeneratorTests/testGenerateWithURL.Contents-PluginList-PluginListInterface.txt
@@ -1,8 +1,27 @@
 //___FILEHEADER___
 
+import Nodes
+
 /*
  This file contains the protocols and types of the plugin list interface requiring public ACL for use in another module.
  */
+
+/// Defines the delegate protocol through which the `Context` interfaces with its listener.
+/// @mockable
+@MainActor
+internal protocol ___VARIABLE_productName___Listener: AnyObject {}
+
+/// @mockable
+@MainActor
+internal protocol ___VARIABLE_productName___Flow: ViewControllableFlow {}
+
+/// @mockable
+@MainActor
+internal protocol ___VARIABLE_productName___Builder: AnyObject {
+    func build(
+        withListener listener: ___VARIABLE_productName___Listener
+    ) -> ___VARIABLE_productName___Flow
+}
 
 /// Declares the type of key used to identify plugins within the collection.
 /// - NOTE: May be any ``Hashable`` type such as ``String`` or an enumeration.

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testPluginListXcodeTemplatePermutation.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplatePermutationTests/testPluginListXcodeTemplatePermutation.1.txt
@@ -9,8 +9,9 @@
       - "<dependencyInjectionImport>"
       - "<pluginListImport>"
       - "Nodes"
-    ▿ pluginListInterfaceImports: 1 element
+    ▿ pluginListInterfaceImports: 2 elements
       - "<baseImport>"
+      - "Nodes"
     - pluginListName: "___VARIABLE_productName___"
     ▿ pluginListTestsImports: 2 elements
       - "<baseTestImport>"

--- a/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testPluginListXcodeTemplate.1.txt
+++ b/Tests/NodesGeneratorTests/__Snapshots__/XcodeTemplateTests/testPluginListXcodeTemplate.1.txt
@@ -12,8 +12,9 @@
           - "<dependencyInjectionImport>"
           - "<pluginListImport>"
           - "Nodes"
-        ▿ pluginListInterfaceImports: 1 element
+        ▿ pluginListInterfaceImports: 2 elements
           - "<baseImport>"
+          - "Nodes"
         - pluginListName: "___VARIABLE_productName___"
         ▿ pluginListTestsImports: 2 elements
           - "<baseTestImport>"


### PR DESCRIPTION
This moves the declarations for Flow Listener and Builder out of the PluginList stencil file and into the PluginListInterface file. 